### PR TITLE
Fix regex for expressions

### DIFF
--- a/src/Zip/FileSelector.cs
+++ b/src/Zip/FileSelector.cs
@@ -926,7 +926,7 @@ namespace Ionic
                     new string[] { @"(.)\)\)", "$1) )" },
 
                     // C. single open paren with a following word - insert a space between
-                    new string[] { @"\((\S)", "( $1" },
+                    new string[] { @"\(([^'\f\n\r\t\v\x85\p{Z}])", "( $1" },
 
                     // D. single close paren with a preceding word - insert a space between the two
                     new string[] { @"(\S)\)", "$1 )" },
@@ -939,7 +939,7 @@ namespace Ionic
                     new string[] { @"(\S)\(", "$1 (" },
 
                     // G. single close paren followed by word - insert a paren after close paren
-                    new string[] { @"\)(\S)", ") $1" },
+                    new string[] { @"\)([^'\f\n\r\t\v\x85\p{Z}])", ") $1" },
 
                     // H. insert space between = and a following single quote
                     //new string[] { @"(=|!=)('[^']*')", "$1 $2" },


### PR DESCRIPTION
Previously \S was used in these two cases which means any character except white-spaces (see http://regexlib.com/CheatSheet.aspx?AspxAutoDetectCookieSupport=1). This means that also single quote characters were selected, as for example in the case `name = 'test)'`. I changed the regexp to also exclude the single quote character.

This should fix https://github.com/haf/DotNetZip.Semverd/issues/20
