### PR TITLE
Fix ZipFile.SelectEntries on Unix

### DIFF
--- a/src/Zip/FileSelector.cs
+++ b/src/Zip/FileSelector.cs
@@ -249,7 +249,7 @@ namespace Ionic
                 // workitem 8245
                 if (Directory.Exists(value))
                 {
-                    _MatchingFileSpec = ".\\" + value + "\\*.*";
+                    _MatchingFileSpec = "." + Path.DirectorySeparatorChar + value + Path.DirectorySeparatorChar + "*.*";
                 }
                 else
                 {
@@ -295,7 +295,7 @@ namespace Ionic
             CriterionTrace("NameCriterion::Evaluate({0})", fullpath);
             // No slash in the pattern implicitly means recurse, which means compare to
             // filename only, not full path.
-            String f = (_MatchingFileSpec.IndexOf('\\') == -1)
+            String f = (_MatchingFileSpec.IndexOf(Path.DirectorySeparatorChar) == -1)
                 ? System.IO.Path.GetFileName(fullpath)
                 : fullpath; // compare to fullpath
 
@@ -1164,6 +1164,10 @@ namespace Ionic
 
                             // if (m.StartsWith("'"))
                             //     m = m.Replace("\u0006", " ");
+
+                            //Fix for Unix -> NormalizeCriteriaExpression replaces all slashes with backslashes
+                            if (Path.DirectorySeparatorChar == '/')
+                                m = m.Replace('\\', Path.DirectorySeparatorChar);
 
                             current = new NameCriterion
                             {

--- a/src/Zip/ZipFile.Selector.cs
+++ b/src/Zip/ZipFile.Selector.cs
@@ -1255,8 +1255,8 @@ namespace Ionic
     {
         internal override bool Evaluate(Ionic.Zip.ZipEntry entry)
         {
-            // swap forward slashes in the entry.FileName for backslashes
-            string transformedFileName = entry.FileName.Replace("/", "\\");
+            // swap slashes in reference to local configuration
+            string transformedFileName = entry.FileName.Replace(Path.DirectorySeparatorChar == '/' ? '\\' : '/', Path.DirectorySeparatorChar);
 
             return _Evaluate(transformedFileName);
         }


### PR DESCRIPTION
Improve mono / unix compatibility by removing hardcoded backslashed
paths which prevented ZipFile.SelectEntries to work

Before, it always returned 0 entries because the filenames were not properly parsed.