### PR TITLE
Fixed NullReferenceException.

### DIFF
--- a/src/Zip/ZipEntry.Write.cs
+++ b/src/Zip/ZipEntry.Write.cs
@@ -1414,6 +1414,7 @@ namespace Ionic.Zip
                     // allow the application to close the stream
                     if (this._CloseDelegate != null)
                         this._CloseDelegate(this.FileName, input);
+                    this._sourceStream = null;
                 }
                 else if ((input as FileStream) != null)
                 {


### PR DESCRIPTION
A NullReferenceException was being thrown when a ZipEntry was added with
ZipFile.AddEntry(string, OpenDelegate, CloseDelegate) and ZipFile
attempted a second pass on the input stream. This change forces the
ZipEntry to reopen the stream.