### PR TITLE
Fix parallel deflate test case

### DIFF
--- a/src/Zlib Tests/ZlibUnitTest1.cs
+++ b/src/Zlib Tests/ZlibUnitTest1.cs
@@ -1835,17 +1835,16 @@ namespace Ionic.Zlib.Tests
             {
                 TestContext.WriteLine("{0}: Creating zip...", sw.Elapsed);
                 using (Stream compressor = new Ionic.Zlib.ParallelDeflateOutputStream(s, true))
-                {
                     compressor.Write(new byte[sz], 0, sz);
-                    s.Position = 0;
-                }
 
+                s.Position = 0;
                 TestContext.WriteLine("{0}: Trying to extract...", sw.Elapsed);
                 using (Stream decompressor = new Ionic.Zlib.DeflateStream(s, Ionic.Zlib.CompressionMode.Decompress, true))
                 {
                     try
                     {
-                        decompressor.Read(new byte[sz], 0, sz);
+                        int bread = decompressor.Read(new byte[sz], 0, sz);
+                        Assert.AreEqual(sz, bread, "Size of decompressed bytes does not match size of input bytes");
                     }
                     catch (Ionic.Zlib.ZlibException)
                     {


### PR DESCRIPTION
Fix a bug within the parallel deflate test case, where are a reset of the stream's position may lead to a fail of the test.

Fix for https://github.com/haf/DotNetZip.Semverd/issues/48