### PR TITLE
Fix "Corrupt ZIP file if calling Save twice with UpdateEntry in between #51"

### DIFF
--- a/src/Zip Tests/UpdateTests.cs
+++ b/src/Zip Tests/UpdateTests.cs
@@ -1080,7 +1080,7 @@ namespace Ionic.Zip.Tests.Update
         {
             string filename = "text.txt";
             string contentText1 = "Content 1";
-            string contentText2 = "Content 2";
+            string contentText2 = "Content 2 - this is longer";
 
             // select the name of the zip file
             string zipFileToCreate = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateTwice.zip");
@@ -1090,7 +1090,8 @@ namespace Ionic.Zip.Tests.Update
             using (ZipFile zip1 = new ZipFile())
             {
                 var content1 = new MemoryStream(Encoding.Default.GetBytes(contentText1));
-                zip1.UpdateEntry(filename, content1);
+                var entry1 = zip1.UpdateEntry(filename, content1);
+                Assert.IsNotNull(entry1);
                 zip1.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateTwice(): This archive will be updated.";
                 zip1.Save(zipFileToCreate);
 
@@ -1106,7 +1107,8 @@ namespace Ionic.Zip.Tests.Update
                 }
 
                 var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
-                zip1.UpdateEntry(filename, content2);
+                var entry2 = zip1.UpdateEntry(filename, content2);
+                Assert.IsNotNull(entry2);
                 zip1.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateTwice(): This archive was updated.";
                 zip1.Save(zipFileToCreate);
 

--- a/src/Zip Tests/UpdateTests.cs
+++ b/src/Zip Tests/UpdateTests.cs
@@ -1076,6 +1076,55 @@ namespace Ionic.Zip.Tests.Update
 
 
         [TestMethod]
+        public void UpdateZip_UpdateItem_UpdateTwice()
+        {
+            string filename = "text.txt";
+            string contentText1 = "Content 1";
+            string contentText2 = "Content 2";
+
+            // select the name of the zip file
+            string zipFileToCreate = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateTwice.zip");
+
+            // Create the zip file
+            Directory.SetCurrentDirectory(TopLevelDir);
+            using (ZipFile zip1 = new ZipFile())
+            {
+                var content1 = new MemoryStream(Encoding.Default.GetBytes(contentText1));
+                zip1.UpdateEntry(filename, content1);
+                zip1.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateTwice(): This archive will be updated.";
+                zip1.Save(zipFileToCreate);
+
+                using (ZipFile zip2 = new ZipFile(zipFileToCreate))
+                {
+                    var entry = zip2[filename];
+                    using (var ms = new MemoryStream())
+                    {
+                        entry.OpenReader().CopyTo(ms);
+                        var content = Encoding.Default.GetString(ms.ToArray());
+                        Assert.AreEqual(contentText1, content);
+                    }
+                }
+
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                zip1.UpdateEntry(filename, content2);
+                zip1.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateTwice(): This archive was updated.";
+                zip1.Save(zipFileToCreate);
+
+                using (ZipFile zip3 = new ZipFile(zipFileToCreate))
+                {
+                    var entry = zip3[filename];
+                    using (var ms = new MemoryStream())
+                    {
+                        entry.OpenReader().CopyTo(ms);
+                        var content = Encoding.Default.GetString(ms.ToArray());
+                        Assert.AreEqual(contentText2, content);
+                    }
+                }
+            }
+        }
+
+
+        [TestMethod]
         public void UpdateZip_AddFile_NewEntriesWithPassword()
         {
             string password = "V.Secret!";

--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -2373,7 +2373,8 @@ namespace Ionic.Zip
                         {
                             if (e1.FileName == e2.FileName)
                             {
-                                e2.CopyMetaData(e1);
+                                if (!e2.IsChanged)
+                                    e2.CopyMetaData(e1);
                                 break;
                             }
                         }


### PR DESCRIPTION
This fixes #51 by only copying the metadata from the just saved file if the entry in question did not change. Unit test is also included.