### PR TITLE
Set the temp file in the same folder of zip file.

### DIFF
--- a/src/Zip/ZipSegmentedStream.cs
+++ b/src/Zip/ZipSegmentedStream.cs
@@ -422,7 +422,8 @@ namespace Ionic.Zip
             {
                 try
                 {
-                    _currentTempName = SharedUtilities.InternalGetTempFileName();
+                    _currentTempName = Path.Combine(Path.GetDirectoryName(CurrentName), 
+                                                    SharedUtilities.InternalGetTempFileName());
                     // move the .z0x file back to a temp name
                     File.Move(CurrentName, _currentTempName);
                     break; // workitem 12403


### PR DESCRIPTION
This pull request is able to fix an issue found by @somepad
https://github.com/haf/DotNetZip.Semverd/issues/8
