### PR TITLE
Case-insensitive de-duplication on read

### DIFF
--- a/src/Zip/ZipDirEntry.cs
+++ b/src/Zip/ZipDirEntry.cs
@@ -60,6 +60,9 @@ namespace Ionic.Zip
 
             // set _LengthOfHeader to 0, to indicate we need to read later.
             this._LengthOfHeader = 0;
+
+            // reset the copy counter because we've got a good entry now
+            CopyHelper.Reset();
         }
 
         /// <summary>
@@ -117,6 +120,11 @@ namespace Ionic.Zip
                 new System.Text.RegularExpressions.Regex(" \\(copy (\\d+)\\)$");
 
             private static int callCount = 0;
+
+            internal static void Reset()
+            {
+                callCount = 0;
+            }
 
             internal static string AppendCopyToFileName(string f)
             {

--- a/src/Zip/ZipFile.Read.cs
+++ b/src/Zip/ZipFile.Read.cs
@@ -722,7 +722,8 @@ namespace Ionic.Zip
             bool inputUsesZip64 = false;
             ZipEntry de;
             // in lieu of hashset, use a dictionary
-            var previouslySeen = new Dictionary<String,object>();
+            var sc = (zf.CaseSensitiveRetrieval) ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+            var previouslySeen = new Dictionary<String,object>(sc);
             while ((de = ZipEntry.ReadDirEntry(zf, previouslySeen)) != null)
             {
                 de.ResetDirEntry();


### PR DESCRIPTION
When reading a zip file that contains multiple entries that differ only in case, consider them as duplicates if `CaseSensitiveRetrieval` is false (as by default).

This will internally rename the second and subsequent such files instead of throwing an exception that makes the whole zip file unreadable.