### PR TITLE
Fix reading of zip files containing entries differing only in case

### DIFF
--- a/src/Zip/ZipFile.AddUpdate.cs
+++ b/src/Zip/ZipFile.AddUpdate.cs
@@ -2067,6 +2067,8 @@ namespace Ionic.Zip
         internal void InternalAddEntry(String name, ZipEntry entry)
         {
             _entries.Add(name, entry);
+            if (!_entriesInsensitive.ContainsKey(name))
+                _entriesInsensitive.Add(name, entry);
             _zipEntriesAsList = null;
             _contentsChanged = true;
         }

--- a/src/Zip/ZipFile.Read.cs
+++ b/src/Zip/ZipFile.Read.cs
@@ -722,7 +722,7 @@ namespace Ionic.Zip
             bool inputUsesZip64 = false;
             ZipEntry de;
             // in lieu of hashset, use a dictionary
-            var previouslySeen = new Dictionary<String,object>();
+            var previouslySeen = new Dictionary<String, object>(StringComparer.Ordinal);
             while ((de = ZipEntry.ReadDirEntry(zf, previouslySeen)) != null)
             {
                 de.ResetDirEntry();
@@ -732,6 +732,8 @@ namespace Ionic.Zip
                     zf.StatusMessageTextWriter.WriteLine("entry {0}", de.FileName);
 
                 zf._entries.Add(de.FileName,de);
+                if (!zf._entriesInsensitive.ContainsKey(de.FileName))
+                    zf._entriesInsensitive.Add(de.FileName,de);
 
                 // workitem 9214
                 if (de._InputUsesZip64) inputUsesZip64 = true;
@@ -765,8 +767,8 @@ namespace Ionic.Zip
         private static void ReadIntoInstance_Orig(ZipFile zf)
         {
             zf.OnReadStarted();
-            //zf._entries = new System.Collections.Generic.List<ZipEntry>();
-            zf._entries = new System.Collections.Generic.Dictionary<String,ZipEntry>();
+            zf._entries.Clear();
+            zf._entriesInsensitive.Clear();
 
             ZipEntry e;
             if (zf.Verbose)
@@ -784,6 +786,8 @@ namespace Ionic.Zip
                     zf.StatusMessageTextWriter.WriteLine("  {0}", e.FileName);
 
                 zf._entries.Add(e.FileName,e);
+                if (!zf._entriesInsensitive.ContainsKey(e.FileName))
+                    zf._entriesInsensitive.Add(e.FileName,e);
                 firstEntry = false;
             }
 
@@ -794,7 +798,7 @@ namespace Ionic.Zip
             {
                 ZipEntry de;
                 // in lieu of hashset, use a dictionary
-                var previouslySeen = new Dictionary<String,Object>();
+                var previouslySeen = new Dictionary<String,Object>(StringComparer.Ordinal);
                 while ((de = ZipEntry.ReadDirEntry(zf, previouslySeen)) != null)
                 {
                     // Housekeeping: Since ZipFile exposes ZipEntry elements in the enumerator,


### PR DESCRIPTION
Alternate fix for #65.

This leaves case-duplicated (multiple entries that differ only in case) alone when reading and writing zip files, and makes `CaseSensitiveRetrieval` only affect searching, as probably originally intended.  Note that enumerating the zip file will still return all entries using their original case, including such duplicates -- but this is also probably as intended.

Mostly, this eliminates an exception that previously occurred when trying to read such files without setting `CaseSensitiveRetrieval` to true prior to reading the file via `Initialize` rather than `Read`.

Minor caveat is that removing entries from zip files will be marginally slower (probably not noticeably so except for zip files with a huge number of entries), but this doesn't seem significant.

Note that this patch does not change the de-duplication-renaming behaviour (as discussed in #65) in any way, as this is no longer triggered by such files.  (It will only trigger if a zip file contains entries that are identical including case.)