### PR TITLE
Fix problems when opening ZIP files, editing an entry and saving more than once afterwards

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
 :minor: 9
-:patch: 8
+:patch: 9
 :special: ''
 :metadata: ''

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -2,6 +2,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-[assembly: AssemblyVersion("1.9.8")]
-[assembly: AssemblyFileVersion("1.9.8")]
-[assembly: AssemblyInformationalVersion("1.9.8.5a841a")]
+[assembly: AssemblyVersion("1.9.9")]
+[assembly: AssemblyFileVersion("1.9.9")]
+[assembly: AssemblyInformationalVersion("1.9.9.e09c70d")]

--- a/src/Zip Tests/UpdateTests.cs
+++ b/src/Zip Tests/UpdateTests.cs
@@ -1318,11 +1318,9 @@ namespace Ionic.Zip.Tests.Update
                 Assert.IsNotNull(entry2);
                 zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated once.";
 
-                using (var memoryStream = new MemoryStream())
-                {
-                    zipSave.Save(memoryStream);
-                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
-                }
+                var memoryStream = new MemoryStream(); //Attention: the source stream can't be disposed, as its needed to read not edited entries on the next save
+                zipSave.Save(memoryStream);
+                File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
                 Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
 
                 var content3 = new MemoryStream(Encoding.Default.GetBytes(contentText3));
@@ -1330,11 +1328,9 @@ namespace Ionic.Zip.Tests.Update
                 Assert.IsNotNull(entry3);
                 zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated twice.";
 
-                using (var memoryStream = new MemoryStream())
-                {
-                    zipSave.Save(memoryStream);
-                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
-                }
+                memoryStream = new MemoryStream();
+                zipSave.Save(memoryStream);
+                File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
             }
 
             Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
@@ -1401,11 +1397,9 @@ namespace Ionic.Zip.Tests.Update
                 Assert.IsNotNull(entry2);
                 zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated once.";
 
-                using (var memoryStream = new MemoryStream())
-                {
-                    zipSave.Save(memoryStream);
-                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
-                }
+                var memoryStream = new MemoryStream(); //Attention: the source stream can't be disposed, as its needed to read not edited entries on the next save
+                zipSave.Save(memoryStream);
+                File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
                 Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
 
                 var content3 = new MemoryStream(Encoding.Default.GetBytes(contentText3));
@@ -1413,11 +1407,9 @@ namespace Ionic.Zip.Tests.Update
                 Assert.IsNotNull(entry3);
                 zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated twice.";
 
-                using (var memoryStream = new MemoryStream())
-                {
-                    zipSave.Save(memoryStream);
-                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
-                }
+                memoryStream = new MemoryStream();
+                zipSave.Save(memoryStream);
+                File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
             }
 
             Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));

--- a/src/Zip Tests/UpdateTests.cs
+++ b/src/Zip Tests/UpdateTests.cs
@@ -1127,6 +1127,78 @@ namespace Ionic.Zip.Tests.Update
 
 
         [TestMethod]
+        public void UpdateZip_UpdateItem_UpdateMultipleTimes()
+        {
+            string filename = "text1.txt";
+            string filename2 = "text2.txt";
+            string contentText1 = "Content 1";
+            string contentText2 = "Content 2 - this is longer";
+            string contentText3 = "Content 3";
+
+            // select the name of the zip file
+            string zipFileToCreate = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes.zip");
+            string zipFileToSaveAs = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes_New.zip");
+
+            #region Create the zip file
+
+            Directory.SetCurrentDirectory(TopLevelDir);
+            using (ZipFile zipSave = new ZipFile())
+            {
+                var content1 = new MemoryStream(Encoding.Default.GetBytes(contentText1));
+                var entry1 = zipSave.UpdateEntry(filename, content1);
+                Assert.IsNotNull(entry1);
+
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename2, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive will be updated.";
+                zipSave.Save(zipFileToCreate);
+            }
+            using (ZipFile zipTest = new ZipFile(zipFileToCreate))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText1, content);
+                }
+            }
+
+            #endregion
+
+            using (ZipFile zipSave = new ZipFile(zipFileToCreate))
+            {
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated once.";
+                zipSave.Save(zipFileToSaveAs);
+
+                Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+
+                var content3 = new MemoryStream(Encoding.Default.GetBytes(contentText3));
+                var entry3 = zipSave.UpdateEntry(filename, content3);
+                Assert.IsNotNull(entry3);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated twice.";
+                zipSave.Save();
+            }
+
+            Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+            using (ZipFile zipTest = new ZipFile(zipFileToSaveAs))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText3, content);
+                }
+            }
+        }
+
+
+        [TestMethod]
         public void UpdateZip_AddFile_NewEntriesWithPassword()
         {
             string password = "V.Secret!";

--- a/src/Zip Tests/UpdateTests.cs
+++ b/src/Zip Tests/UpdateTests.cs
@@ -1271,6 +1271,170 @@ namespace Ionic.Zip.Tests.Update
 
 
         [TestMethod]
+        public void UpdateZip_UpdateItem_UpdateMultipleTimes_SaveAsStream()
+        {
+            string filename = "text1.txt";
+            string filename2 = "text2.txt";
+            string contentText1 = "Content 1";
+            string contentText2 = "Content 2 - this is longer";
+            string contentText3 = "Content 3";
+
+            // select the name of the zip file
+            string zipFileToCreate = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes.zip");
+            string zipFileToSaveAs = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes_New.zip");
+
+            #region Create the zip file
+
+            Directory.SetCurrentDirectory(TopLevelDir);
+            using (ZipFile zipSave = new ZipFile())
+            {
+                var content1 = new MemoryStream(Encoding.Default.GetBytes(contentText1));
+                var entry1 = zipSave.UpdateEntry(filename, content1);
+                Assert.IsNotNull(entry1);
+
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename2, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive will be updated.";
+                zipSave.Save(zipFileToCreate);
+            }
+            using (ZipFile zipTest = new ZipFile(zipFileToCreate))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText1, content);
+                }
+            }
+
+            #endregion
+
+            using (ZipFile zipSave = new ZipFile(zipFileToCreate))
+            {
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated once.";
+
+                using (var memoryStream = new MemoryStream())
+                {
+                    zipSave.Save(memoryStream);
+                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
+                }
+                Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+
+                var content3 = new MemoryStream(Encoding.Default.GetBytes(contentText3));
+                var entry3 = zipSave.UpdateEntry(filename, content3);
+                Assert.IsNotNull(entry3);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated twice.";
+
+                using (var memoryStream = new MemoryStream())
+                {
+                    zipSave.Save(memoryStream);
+                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
+                }
+            }
+
+            Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+            using (ZipFile zipTest = new ZipFile(zipFileToSaveAs))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText3, content);
+                }
+            }
+        }
+
+
+        [TestMethod]
+        public void UpdateZip_UpdateItem_UpdateMultipleTimesFromStream_SaveAsStream()
+        {
+            string filename = "text1.txt";
+            string filename2 = "text2.txt";
+            string contentText1 = "Content 1";
+            string contentText2 = "Content 2 - this is longer";
+            string contentText3 = "Content 3";
+
+            // select the name of the zip file
+            string zipFileToCreate = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes.zip");
+            string zipFileToSaveAs = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes_New.zip");
+
+            #region Create the zip file
+
+            Directory.SetCurrentDirectory(TopLevelDir);
+            using (ZipFile zipSave = new ZipFile())
+            {
+                var content1 = new MemoryStream(Encoding.Default.GetBytes(contentText1));
+                var entry1 = zipSave.UpdateEntry(filename, content1);
+                Assert.IsNotNull(entry1);
+
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename2, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive will be updated.";
+                zipSave.Save(zipFileToCreate);
+            }
+            using (ZipFile zipTest = new ZipFile(zipFileToCreate))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText1, content);
+                }
+            }
+
+            #endregion
+
+            var zipData = File.ReadAllBytes(zipFileToCreate);
+            var sourceStream = new MemoryStream(zipData);
+            using (ZipFile zipSave = ZipFile.Read(sourceStream))
+            {
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated once.";
+
+                using (var memoryStream = new MemoryStream())
+                {
+                    zipSave.Save(memoryStream);
+                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
+                }
+                Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+
+                var content3 = new MemoryStream(Encoding.Default.GetBytes(contentText3));
+                var entry3 = zipSave.UpdateEntry(filename, content3);
+                Assert.IsNotNull(entry3);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated twice.";
+
+                using (var memoryStream = new MemoryStream())
+                {
+                    zipSave.Save(memoryStream);
+                    File.WriteAllBytes(zipFileToSaveAs, memoryStream.ToArray());
+                }
+            }
+
+            Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+            using (ZipFile zipTest = new ZipFile(zipFileToSaveAs))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText3, content);
+                }
+            }
+        }
+
+
+        [TestMethod]
         public void UpdateZip_AddFile_NewEntriesWithPassword()
         {
             string password = "V.Secret!";

--- a/src/Zip Tests/UpdateTests.cs
+++ b/src/Zip Tests/UpdateTests.cs
@@ -1127,7 +1127,7 @@ namespace Ionic.Zip.Tests.Update
 
 
         [TestMethod]
-        public void UpdateZip_UpdateItem_UpdateMultipleTimes()
+        public void UpdateZip_UpdateItem_UpdateMultipleTimes_SaveAs_Save()
         {
             string filename = "text1.txt";
             string filename2 = "text2.txt";
@@ -1182,6 +1182,78 @@ namespace Ionic.Zip.Tests.Update
                 Assert.IsNotNull(entry3);
                 zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated twice.";
                 zipSave.Save();
+            }
+
+            Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+            using (ZipFile zipTest = new ZipFile(zipFileToSaveAs))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText3, content);
+                }
+            }
+        }
+
+
+        [TestMethod]
+        public void UpdateZip_UpdateItem_UpdateMultipleTimes_SaveAsTwice()
+        {
+            string filename = "text1.txt";
+            string filename2 = "text2.txt";
+            string contentText1 = "Content 1";
+            string contentText2 = "Content 2 - this is longer";
+            string contentText3 = "Content 3";
+
+            // select the name of the zip file
+            string zipFileToCreate = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes.zip");
+            string zipFileToSaveAs = Path.Combine(TopLevelDir, "UpdateZip_UpdateItem_UpdateMultipleTimes_New.zip");
+
+            #region Create the zip file
+
+            Directory.SetCurrentDirectory(TopLevelDir);
+            using (ZipFile zipSave = new ZipFile())
+            {
+                var content1 = new MemoryStream(Encoding.Default.GetBytes(contentText1));
+                var entry1 = zipSave.UpdateEntry(filename, content1);
+                Assert.IsNotNull(entry1);
+
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename2, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive will be updated.";
+                zipSave.Save(zipFileToCreate);
+            }
+            using (ZipFile zipTest = new ZipFile(zipFileToCreate))
+            {
+                var entry = zipTest[filename];
+                using (var ms = new MemoryStream())
+                {
+                    entry.OpenReader().CopyTo(ms);
+                    var content = Encoding.Default.GetString(ms.ToArray());
+                    Assert.AreEqual(contentText1, content);
+                }
+            }
+
+            #endregion
+
+            using (ZipFile zipSave = new ZipFile(zipFileToCreate))
+            {
+                var content2 = new MemoryStream(Encoding.Default.GetBytes(contentText2));
+                var entry2 = zipSave.UpdateEntry(filename, content2);
+                Assert.IsNotNull(entry2);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated once.";
+                zipSave.Save(zipFileToSaveAs);
+
+                Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));
+
+                var content3 = new MemoryStream(Encoding.Default.GetBytes(contentText3));
+                var entry3 = zipSave.UpdateEntry(filename, content3);
+                Assert.IsNotNull(entry3);
+                zipSave.Comment = "UpdateTests::UpdateZip_UpdateItem_UpdateMultipleTimes(): This archive was updated twice.";
+                zipSave.Save(zipFileToSaveAs);
             }
 
             Assert.IsTrue(ZipFile.CheckZip(zipFileToSaveAs));

--- a/src/Zip/ZipFile.Save.cs
+++ b/src/Zip/ZipFile.Save.cs
@@ -538,7 +538,7 @@ namespace Ionic.Zip
         /// </para>
         ///
         /// <code lang="C#">
-        /// using (var fs = new FileSteeam(filename, FileMode.Open))
+        /// using (var fs = new FileStream(filename, FileMode.Open))
         /// {
         ///   using (var zip = Ionic.Zip.ZipFile.Read(inputStream))
         ///   {
@@ -564,7 +564,7 @@ namespace Ionic.Zip
         ///
         /// <param name="outputStream">
         ///   The <c>System.IO.Stream</c> to write to. It must be
-        ///   writable. If you created the ZipFile instanct by calling
+        ///   writable. If you created the ZipFile instance by calling
         ///   ZipFile.Read(), this stream must not be the same stream
         ///   you passed to ZipFile.Read().
         /// </param>

--- a/src/Zip/ZipFile.Save.cs
+++ b/src/Zip/ZipFile.Save.cs
@@ -207,6 +207,25 @@ namespace Ionic.Zip
                 thisSaveUsedZip64 |= directoryNeededZip64;
                 _OutputUsesZip64 = new Nullable<bool>(thisSaveUsedZip64);
 
+                if (_fileAlreadyExists && this._readstream != null)
+                {
+                    // This means we opened and read a zip file.
+                    // If we are now saving, we need to close the orig file, first.
+                    this._readstream.Close();
+                    this._readstream = null;
+                }
+                // the archiveStream for each entry needs to be null
+                foreach (var e in c)
+                {
+                    var zss1 = e._archiveStream as ZipSegmentedStream;
+                    if (zss1 != null)
+#if NETCF
+                        zss1.Close();
+#else
+                        zss1.Dispose();
+#endif
+                    e._archiveStream = null;
+                }
 
                 // do the rename as necessary
                 if (_name != null &&
@@ -219,29 +238,9 @@ namespace Ionic.Zip
 #else
                     WriteStream.Dispose();
 #endif
+
                     if (_saveOperationCanceled)
                         return;
-
-                    if (_fileAlreadyExists && this._readstream != null)
-                    {
-                        // This means we opened and read a zip file.
-                        // If we are now saving to the same file, we need to close the
-                        // orig file, first.
-                        this._readstream.Close();
-                        this._readstream = null;
-                        // the archiveStream for each entry needs to be null
-                        foreach (var e in c)
-                        {
-                            var zss1 = e._archiveStream as ZipSegmentedStream;
-                            if (zss1 != null)
-#if NETCF
-                                zss1.Close();
-#else
-                                zss1.Dispose();
-#endif
-                            e._archiveStream = null;
-                        }
-                    }
 
                     string tmpName = null;
                     if (File.Exists(_name))
@@ -311,9 +310,9 @@ namespace Ionic.Zip
                         }
 
                     }
-                    _readName = _name;
                     _fileAlreadyExists = true;
                 }
+                _readName = _name;
 
                 NotifyEntriesSaveComplete(c);
                 OnSaveCompleted();
@@ -578,11 +577,17 @@ namespace Ionic.Zip
             // if we had a filename to save to, we are now obliterating it.
             _name = null;
 
+            if(_writestream != null) // if we saved to a stream before read from there
+                _readstream = _writestream;
             _writestream = new CountingStream(outputStream);
 
             _contentsChanged = true;
-            _fileAlreadyExists = false;
+            _fileAlreadyExists = File.Exists(_readName); // if we saved to or read from a file before
+
             Save();
+
+            _fileAlreadyExists = false;
+            _readName = null; // if we had a filename to save to, we are now obliterating it.
         }
 
 

--- a/src/Zip/ZipFile.Save.cs
+++ b/src/Zip/ZipFile.Save.cs
@@ -311,6 +311,7 @@ namespace Ionic.Zip
                         }
 
                     }
+                    _readName = _name;
                     _fileAlreadyExists = true;
                 }
 
@@ -473,7 +474,7 @@ namespace Ionic.Zip
             if (Directory.Exists(_name))
                 throw new ZipException("Bad Directory", new System.ArgumentException("That name specifies an existing directory. Please specify a filename.", "fileName"));
             _contentsChanged = true;
-            _fileAlreadyExists = File.Exists(_name);
+            _fileAlreadyExists = File.Exists(_readName);
             Save();
         }
 

--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -2358,10 +2358,19 @@ namespace Ionic.Zip
                 // read in the just-saved zip archive
                 using (ZipFile x = new ZipFile())
                 {
-                    // workitem 10735
-                    x._readName = x._name = whileSaving
-                        ? (this._readName ?? this._name)
-                        : this._name;
+                    if (File.Exists(this._readName ?? this._name))
+                    {
+                        // workitem 10735
+                        x._readName = x._name = whileSaving
+                            ? (this._readName ?? this._name)
+                            : this._name;
+                    }
+                    else // if we just saved to a stream no file is available to read from
+                    {
+                        if (_readstream.CanSeek)
+                            _readstream.Seek(0, SeekOrigin.Begin);
+                        x._readstream = _readstream;
+                    }
                     x.AlternateEncoding = this.AlternateEncoding;
                     x.AlternateEncodingUsage = this.AlternateEncodingUsage;
                     ReadIntoInstance(x);


### PR DESCRIPTION
There was a problem when you executed the following:

1) Open an exisitng ZIP file with at least 2 entries
2) Edit at least one entry **changing it's size**, but **do not touch** at least **one entry after** an edited one
3) Save the ZIP file to a new file, **different than the one which was opened**
4) Save the ZIP file again

What happened at 4) was, that the not changed entry from 2) was read from the initial ZIP file, but with the meta-data from 3) -> the resulting ZIP file of 4) was corrupt as the data read for that entry is shifted.

To fix that when working with files I made sure that the file-name/stream, which is used to read not-edited-entries from, was updated correctly after saving to a new file. As for files only the file-name was used this problem did not occur when saving to the same file, as in that case the "old file-name" and the "new file-name" where identical.  
To fix the same problem when working with streams I had to change/move some code to ensure all streams used where properly removed/reassigned (e.g. `ZipEntry.ArchiveStream` is required to be set to `null`, otherwise it will always try to read from the initial stream).

I created unit tests for these use-cases which are successful now and as far as I was able to run the other unit test I did not break anything there (i.e. the tests which ran successful before still do, but I'm not able to run all of them).