### PR TITLE
Ignore duplicates

### DIFF
--- a/src/Zip/ZipDirEntry.cs
+++ b/src/Zip/ZipDirEntry.cs
@@ -60,6 +60,9 @@ namespace Ionic.Zip
 
             // set _LengthOfHeader to 0, to indicate we need to read later.
             this._LengthOfHeader = 0;
+
+            // reset the copy counter because we've got a good entry now
+            CopyHelper.Reset();
         }
 
         /// <summary>
@@ -117,6 +120,11 @@ namespace Ionic.Zip
                 new System.Text.RegularExpressions.Regex(" \\(copy (\\d+)\\)$");
 
             private static int callCount = 0;
+
+            internal static void Reset()
+            {
+                callCount = 0;
+            }
 
             internal static string AppendCopyToFileName(string f)
             {

--- a/src/Zip/ZipDirEntry.cs
+++ b/src/Zip/ZipDirEntry.cs
@@ -199,168 +199,175 @@ namespace Ionic.Zip
                 ? zf.AlternateEncoding
                 : ZipFile.DefaultEncoding;
 
-            int signature = Ionic.Zip.SharedUtilities.ReadSignature(s);
-            // return null if this is not a local file header signature
-            if (IsNotValidZipDirEntrySig(signature))
+            while (true)
             {
-                s.Seek(-4, System.IO.SeekOrigin.Current);
-                // workitem 10178
-                Ionic.Zip.SharedUtilities.Workaround_Ladybug318918(s);
-
-                // Getting "not a ZipDirEntry signature" here is not always wrong or an
-                // error.  This can happen when walking through a zipfile.  After the
-                // last ZipDirEntry, we expect to read an
-                // EndOfCentralDirectorySignature.  When we get this is how we know
-                // we've reached the end of the central directory.
-                if (signature != ZipConstants.EndOfCentralDirectorySignature &&
-                    signature != ZipConstants.Zip64EndOfCentralDirectoryRecordSignature &&
-                    signature != ZipConstants.ZipEntrySignature  // workitem 8299
-                    )
+                int signature = Ionic.Zip.SharedUtilities.ReadSignature(s);
+                // return null if this is not a local file header signature
+                if (IsNotValidZipDirEntrySig(signature))
                 {
-                    throw new BadReadException(String.Format("  Bad signature (0x{0:X8}) at position 0x{1:X8}", signature, s.Position));
+                    s.Seek(-4, System.IO.SeekOrigin.Current);
+                    // workitem 10178
+                    Ionic.Zip.SharedUtilities.Workaround_Ladybug318918(s);
+
+                    // Getting "not a ZipDirEntry signature" here is not always wrong or an
+                    // error.  This can happen when walking through a zipfile.  After the
+                    // last ZipDirEntry, we expect to read an
+                    // EndOfCentralDirectorySignature.  When we get this is how we know
+                    // we've reached the end of the central directory.
+                    if (signature != ZipConstants.EndOfCentralDirectorySignature &&
+                        signature != ZipConstants.Zip64EndOfCentralDirectoryRecordSignature &&
+                        signature != ZipConstants.ZipEntrySignature  // workitem 8299
+                        )
+                    {
+                        throw new BadReadException(String.Format("  Bad signature (0x{0:X8}) at position 0x{1:X8}", signature, s.Position));
+                    }
+                    return null;
                 }
-                return null;
-            }
 
-            int bytesRead = 42 + 4;
-            byte[] block = new byte[42];
-            int n = s.Read(block, 0, block.Length);
-            if (n != block.Length) return null;
+                int bytesRead = 42 + 4;
+                byte[] block = new byte[42];
+                int n = s.Read(block, 0, block.Length);
+                if (n != block.Length) return null;
 
-            int i = 0;
-            ZipEntry zde = new ZipEntry();
-            zde.AlternateEncoding = expectedEncoding;
-            zde._Source = ZipEntrySource.ZipFile;
-            zde._container = new ZipContainer(zf);
+                int i = 0;
+                ZipEntry zde = new ZipEntry();
+                zde.AlternateEncoding = expectedEncoding;
+                zde._Source = ZipEntrySource.ZipFile;
+                zde._container = new ZipContainer(zf);
 
-            unchecked
-            {
-                zde._VersionMadeBy = (short)(block[i++] + block[i++] * 256);
-                zde._VersionNeeded = (short)(block[i++] + block[i++] * 256);
-                zde._BitField = (short)(block[i++] + block[i++] * 256);
-                zde._CompressionMethod = (Int16)(block[i++] + block[i++] * 256);
-                zde._TimeBlob = block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256;
-                zde._LastModified = Ionic.Zip.SharedUtilities.PackedToDateTime(zde._TimeBlob);
-                zde._timestamp |= ZipEntryTimestamp.DOS;
+                unchecked
+                {
+                    zde._VersionMadeBy = (short)(block[i++] + block[i++] * 256);
+                    zde._VersionNeeded = (short)(block[i++] + block[i++] * 256);
+                    zde._BitField = (short)(block[i++] + block[i++] * 256);
+                    zde._CompressionMethod = (Int16)(block[i++] + block[i++] * 256);
+                    zde._TimeBlob = block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256;
+                    zde._LastModified = Ionic.Zip.SharedUtilities.PackedToDateTime(zde._TimeBlob);
+                    zde._timestamp |= ZipEntryTimestamp.DOS;
 
-                zde._Crc32 = block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256;
-                zde._CompressedSize = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
-                zde._UncompressedSize = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
-            }
+                    zde._Crc32 = block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256;
+                    zde._CompressedSize = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
+                    zde._UncompressedSize = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
+                }
 
-            // preserve
-            zde._CompressionMethod_FromZipFile = zde._CompressionMethod;
+                // preserve
+                zde._CompressionMethod_FromZipFile = zde._CompressionMethod;
 
-            zde._filenameLength = (short)(block[i++] + block[i++] * 256);
-            zde._extraFieldLength = (short)(block[i++] + block[i++] * 256);
-            zde._commentLength = (short)(block[i++] + block[i++] * 256);
-            zde._diskNumber = (UInt32)(block[i++] + block[i++] * 256);
+                zde._filenameLength = (short)(block[i++] + block[i++] * 256);
+                zde._extraFieldLength = (short)(block[i++] + block[i++] * 256);
+                zde._commentLength = (short)(block[i++] + block[i++] * 256);
+                zde._diskNumber = (UInt32)(block[i++] + block[i++] * 256);
 
-            zde._InternalFileAttrs = (short)(block[i++] + block[i++] * 256);
-            zde._ExternalFileAttrs = block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256;
+                zde._InternalFileAttrs = (short)(block[i++] + block[i++] * 256);
+                zde._ExternalFileAttrs = block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256;
 
-            zde._RelativeOffsetOfLocalHeader = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
+                zde._RelativeOffsetOfLocalHeader = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
 
-            // workitem 7801
-            zde.IsText = ((zde._InternalFileAttrs & 0x01) == 0x01);
+                // workitem 7801
+                zde.IsText = ((zde._InternalFileAttrs & 0x01) == 0x01);
 
-            block = new byte[zde._filenameLength];
-            n = s.Read(block, 0, block.Length);
-            bytesRead += n;
-            if ((zde._BitField & 0x0800) == 0x0800)
-            {
-                // UTF-8 is in use
-                zde._FileNameInArchive = Ionic.Zip.SharedUtilities.Utf8StringFromBuffer(block);
-            }
-            else
-            {
-                zde._FileNameInArchive = Ionic.Zip.SharedUtilities.StringFromBuffer(block, expectedEncoding);
-            }
-
-            // workitem 10330
-            // insure unique entry names
-            while (previouslySeen.ContainsKey(zde._FileNameInArchive))
-            {
-                zde._FileNameInArchive = CopyHelper.AppendCopyToFileName(zde._FileNameInArchive);
-                zde._metadataChanged = true;
-            }
-
-            if (zde.AttributesIndicateDirectory)
-                zde.MarkAsDirectory();  // may append a slash to filename if nec.
-            // workitem 6898
-            else if (zde._FileNameInArchive.EndsWith("/")) zde.MarkAsDirectory();
-
-            zde._CompressedFileDataSize = zde._CompressedSize;
-            if ((zde._BitField & 0x01) == 0x01)
-            {
-                // this may change after processing the Extra field
-                zde._Encryption_FromZipFile = zde._Encryption =
-                    EncryptionAlgorithm.PkzipWeak;
-                zde._sourceIsEncrypted = true;
-            }
-
-            if (zde._extraFieldLength > 0)
-            {
-                zde._InputUsesZip64 = (zde._CompressedSize == 0xFFFFFFFF ||
-                      zde._UncompressedSize == 0xFFFFFFFF ||
-                      zde._RelativeOffsetOfLocalHeader == 0xFFFFFFFF);
-
-                // Console.WriteLine("  Input uses Z64?:      {0}", zde._InputUsesZip64);
-
-                bytesRead += zde.ProcessExtraField(s, zde._extraFieldLength);
-                zde._CompressedFileDataSize = zde._CompressedSize;
-            }
-
-            // we've processed the extra field, so we know the encryption method is set now.
-            if (zde._Encryption == EncryptionAlgorithm.PkzipWeak)
-            {
-                // the "encryption header" of 12 bytes precedes the file data
-                zde._CompressedFileDataSize -= 12;
-            }
-#if AESCRYPTO
-            else if (zde.Encryption == EncryptionAlgorithm.WinZipAes128 ||
-                        zde.Encryption == EncryptionAlgorithm.WinZipAes256)
-            {
-                zde._CompressedFileDataSize = zde.CompressedSize -
-                    (ZipEntry.GetLengthOfCryptoHeaderBytes(zde.Encryption) + 10);
-                zde._LengthOfTrailer = 10;
-            }
-#endif
-
-            // tally the trailing descriptor
-            if ((zde._BitField & 0x0008) == 0x0008)
-            {
-                // sig, CRC, Comp and Uncomp sizes
-                if (zde._InputUsesZip64)
-                    zde._LengthOfTrailer += 24;
-                else
-                    zde._LengthOfTrailer += 16;
-            }
-
-            // workitem 12744
-            zde.AlternateEncoding = ((zde._BitField & 0x0800) == 0x0800)
-                ? System.Text.Encoding.UTF8
-                :expectedEncoding;
-
-            zde.AlternateEncodingUsage = ZipOption.Always;
-
-            if (zde._commentLength > 0)
-            {
-                block = new byte[zde._commentLength];
+                block = new byte[zde._filenameLength];
                 n = s.Read(block, 0, block.Length);
                 bytesRead += n;
                 if ((zde._BitField & 0x0800) == 0x0800)
                 {
                     // UTF-8 is in use
-                    zde._Comment = Ionic.Zip.SharedUtilities.Utf8StringFromBuffer(block);
+                    zde._FileNameInArchive = Ionic.Zip.SharedUtilities.Utf8StringFromBuffer(block);
                 }
                 else
                 {
-                    zde._Comment = Ionic.Zip.SharedUtilities.StringFromBuffer(block, expectedEncoding);
+                    zde._FileNameInArchive = Ionic.Zip.SharedUtilities.StringFromBuffer(block, expectedEncoding);
                 }
+
+                // workitem 10330
+                // insure unique entry names
+                while (!zf.IgnoreDuplicateFiles && previouslySeen.ContainsKey(zde._FileNameInArchive))
+                {
+                    zde._FileNameInArchive = CopyHelper.AppendCopyToFileName(zde._FileNameInArchive);
+                    zde._metadataChanged = true;
+                }
+
+                if (zde.AttributesIndicateDirectory)
+                    zde.MarkAsDirectory();  // may append a slash to filename if nec.
+                    // workitem 6898
+                else if (zde._FileNameInArchive.EndsWith("/")) zde.MarkAsDirectory();
+
+                zde._CompressedFileDataSize = zde._CompressedSize;
+                if ((zde._BitField & 0x01) == 0x01)
+                {
+                    // this may change after processing the Extra field
+                    zde._Encryption_FromZipFile = zde._Encryption =
+                        EncryptionAlgorithm.PkzipWeak;
+                    zde._sourceIsEncrypted = true;
+                }
+
+                if (zde._extraFieldLength > 0)
+                {
+                    zde._InputUsesZip64 = (zde._CompressedSize == 0xFFFFFFFF ||
+                          zde._UncompressedSize == 0xFFFFFFFF ||
+                          zde._RelativeOffsetOfLocalHeader == 0xFFFFFFFF);
+
+                    // Console.WriteLine("  Input uses Z64?:      {0}", zde._InputUsesZip64);
+
+                    bytesRead += zde.ProcessExtraField(s, zde._extraFieldLength);
+                    zde._CompressedFileDataSize = zde._CompressedSize;
+                }
+
+                // we've processed the extra field, so we know the encryption method is set now.
+                if (zde._Encryption == EncryptionAlgorithm.PkzipWeak)
+                {
+                    // the "encryption header" of 12 bytes precedes the file data
+                    zde._CompressedFileDataSize -= 12;
+                }
+#if AESCRYPTO
+                else if (zde.Encryption == EncryptionAlgorithm.WinZipAes128 ||
+                            zde.Encryption == EncryptionAlgorithm.WinZipAes256)
+                {
+                    zde._CompressedFileDataSize = zde.CompressedSize -
+                        (ZipEntry.GetLengthOfCryptoHeaderBytes(zde.Encryption) + 10);
+                        zde._LengthOfTrailer = 10;
+                }
+#endif
+
+                // tally the trailing descriptor
+                if ((zde._BitField & 0x0008) == 0x0008)
+                {
+                    // sig, CRC, Comp and Uncomp sizes
+                    if (zde._InputUsesZip64)
+                        zde._LengthOfTrailer += 24;
+                    else
+                        zde._LengthOfTrailer += 16;
+                }
+
+                // workitem 12744
+                zde.AlternateEncoding = ((zde._BitField & 0x0800) == 0x0800)
+                    ? System.Text.Encoding.UTF8
+                    :expectedEncoding;
+
+                zde.AlternateEncodingUsage = ZipOption.Always;
+
+                if (zde._commentLength > 0)
+                {
+                    block = new byte[zde._commentLength];
+                    n = s.Read(block, 0, block.Length);
+                    bytesRead += n;
+                    if ((zde._BitField & 0x0800) == 0x0800)
+                    {
+                        // UTF-8 is in use
+                        zde._Comment = Ionic.Zip.SharedUtilities.Utf8StringFromBuffer(block);
+                    }
+                    else
+                    {
+                        zde._Comment = Ionic.Zip.SharedUtilities.StringFromBuffer(block, expectedEncoding);
+                    }
+                }
+                //zde._LengthOfDirEntry = bytesRead;
+                if (zf.IgnoreDuplicateFiles && previouslySeen.ContainsKey(zde._FileNameInArchive))
+                {
+                    continue;
+                }
+                return zde;
             }
-            //zde._LengthOfDirEntry = bytesRead;
-            return zde;
         }
 
 

--- a/src/Zip/ZipFile.cs
+++ b/src/Zip/ZipFile.cs
@@ -840,6 +840,24 @@ namespace Ionic.Zip
 
 
         /// <summary>
+        ///   Indicates whether to ignore duplicate files (report only the first entry)
+        ///   when loading a zipfile.
+        /// </summary>
+        /// 
+        /// <remarks>
+        ///   The default value is <c>false</c>, which will try to make all files
+        ///   available (duplicates will have a "copy" suffix appended to their name).
+        ///   Setting this to <c>true</c> prior to using <c>Initialize</c> to read a
+        ///   zipfile will prevent this and instead just ignore the duplicates.
+        /// </remarks>
+        public bool IgnoreDuplicateFiles
+        {
+            get { return _IgnoreDuplicateFiles; }
+            set { _IgnoreDuplicateFiles = value; }
+        }
+
+
+        /// <summary>
         ///   Indicates whether to encode entry filenames and entry comments using Unicode
         ///   (UTF-8).
         /// </summary>
@@ -3612,6 +3630,7 @@ namespace Ionic.Zip
         #region private fields
         private TextWriter _StatusMessageTextWriter;
         private bool _CaseSensitiveRetrieval;
+        private bool _IgnoreDuplicateFiles;
         private Stream _readstream;
         private Stream _writestream;
         private UInt16 _versionMadeBy;


### PR DESCRIPTION
Given zip files that contain duplicate entries, DotNetZip throws an exception after reading a certain number of duplicate entries in the lifetime of the process (and will thereafter be unable to read zips that contain duplicates at all).  Additionally such files are not read the same twice, even if closed and re-read without modifications (since it picks different numbers to rename the duplicates to each time).

This makes two changes to rectify this.

The first is to fix the duplication renaming counter (as discussed in #65) so that the limit is per-entry (as probably intended) instead of per-process.  This ensures consistent renaming and avoids throwing the exception unless a single zip contains excessive duplications of a single entry.

The second adds an option `IgnoreDuplicateFiles` (disabled by default, but can be enabled by setting the property before calling `Initialize` to read a zip file) that will simply ignore duplicate entries entirely when reading a zip instead of renaming them (under the assumption that they probably contain the same data).

Note that this only affects files that have completely identical filenames -- names that differ in case are still treated as separate entries and will be separately retrievable (via #66) and aren't affected by either of these changes.

Possible future extension might be to make `IgnoreDuplicateFiles` also affect adding files to zips; currently this throws an `ArgumentException` due to the duplicate key in the internal dictionary.  In this case though it's probably better to continue throwing the exception rather than silently ignoring data.  (Be tolerant of your inputs and strict on your outputs.)