### PR TITLE
don't hang if all data already written

### DIFF
--- a/src/Zlib/ParallelDeflateOutputStream.cs
+++ b/src/Zlib/ParallelDeflateOutputStream.cs
@@ -969,7 +969,7 @@ namespace Ionic.Zlib
 
                 } while (nextToWrite >= 0);
 
-            } while (doAll && (_lastWritten != _lastFilled));
+            } while (doAll && (_lastWritten != _latestCompressed || _lastWritten != _lastFilled));
 
             emitting = false;
         }

--- a/src/Zlib/ParallelDeflateOutputStream.cs
+++ b/src/Zlib/ParallelDeflateOutputStream.cs
@@ -880,8 +880,9 @@ namespace Ionic.Zlib
 
             if (emitting) return;
             emitting = true;
-            if (doAll || mustWait)
+            if ((doAll && (_lastCompressed != _lastFilled)) || mustWait) {
                 _newlyCompressedBlob.WaitOne();
+            }
 
             do
             {
@@ -968,7 +969,7 @@ namespace Ionic.Zlib
 
                 } while (nextToWrite >= 0);
 
-            } while (doAll && (_lastWritten != _latestCompressed || _lastWritten != _lastFilled));
+            } while (doAll && (_lastWritten != _lastFilled));
 
             emitting = false;
         }
@@ -1382,5 +1383,4 @@ namespace Ionic.Zlib
     }
 
 }
-
 

--- a/src/Zlib/ParallelDeflateOutputStream.cs
+++ b/src/Zlib/ParallelDeflateOutputStream.cs
@@ -880,7 +880,7 @@ namespace Ionic.Zlib
 
             if (emitting) return;
             emitting = true;
-            if ((doAll && (_lastCompressed != _lastFilled)) || mustWait) {
+            if ((doAll && (_latestCompressed != _lastFilled)) || mustWait) {
                 _newlyCompressedBlob.WaitOne();
             }
 


### PR DESCRIPTION
should resolve #74.

_lastFilled is incremented when work is created
_latestCompressed is set by _DeflateOne
_lastWritten is set by EmitPendingBuffers

All are monotonically incremented.

line 883: if _lastCompressed is equal to _lastFilled then all work is complete, waiting can hang
line 971: if _lastWritten==_lastCompressed, but there is still a worker thread running (ie _lastFilled>_lastCompressed) then the last chunk may not be written by the doAll flush

the change on 971 may slightly change the multi-thread behavior of the proc, if flush(true) is being called from a different thread to write. But in that case the entire current implementation is flaky anyway