### PR TITLE
Fix FileNotFoundException messages

### DIFF
--- a/src/Zip.Shared/Shared.cs
+++ b/src/Zip.Shared/Shared.cs
@@ -40,7 +40,7 @@ namespace Ionic.Zip
         public static Int64 GetFileLength(string fileName)
         {
             if (!File.Exists(fileName))
-                throw new FileNotFoundException(fileName);
+                throw new FileNotFoundException(String.Format("Could not find file '{0}'.", fileName), fileName);
 
             long fileLength;
             FileShare fs = FileShare.ReadWrite;


### PR DESCRIPTION
Was throwing FileNotFoundExceptions with just the filename as the Message - the message should be a readable error message and the filename assigned to the FileName property via the second ctor parameter.