### PR TITLE
tmpName = Path.GetRandomFileName() creates temporary files with random extensions.

### DIFF
--- a/src/Zip.Shared/ZipEntry.Extract.cs
+++ b/src/Zip.Shared/ZipEntry.Extract.cs
@@ -717,7 +717,7 @@ namespace Ionic.Zip
                     EnsurePassword(password);
 
                 // set up the output stream
-                var tmpName = Path.GetRandomFileName();
+                var tmpName = Path.GetRandomFileName()+".tmp";
                 var tmpPath = Path.Combine(Path.GetDirectoryName(targetFileName), tmpName);
                 WriteStatus("extract file {0}...", targetFileName);
 


### PR DESCRIPTION
The problem is that sometimes the extension (which is a random three letters) makes the file look like malware to antivirus programs. This fix adds '.tmp" to give these files a harmless-looking extension.

[This is my first attempt to suggest a change on GitHub. Forgive me if I am doing this incorrectly.]

-- Jeffrey