### PR TITLE
Fix issue #82

### DIFF
--- a/src/Zip.Shared/ZipEntry.Read.cs
+++ b/src/Zip.Shared/ZipEntry.Read.cs
@@ -216,8 +216,6 @@ namespace Ionic.Zip
                         i += 8;
                         ze._UncompressedSize = BitConverter.ToInt64(block, i);
                         i += 8;
-
-                        ze._LengthOfTrailer += 24;  // bytes including sig, CRC, Comp and Uncomp sizes
                     }
                     else
                     {
@@ -234,9 +232,6 @@ namespace Ionic.Zip
                         ze._Crc32 = (Int32)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
                         ze._CompressedSize = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
                         ze._UncompressedSize = (uint)(block[i++] + block[i++] * 256 + block[i++] * 256 * 256 + block[i++] * 256 * 256 * 256);
-
-                        ze._LengthOfTrailer += 16;  // bytes including sig, CRC, Comp and Uncomp sizes
-
                     }
 
                     wantMore = (SizeOfDataRead != ze._CompressedSize);
@@ -261,6 +256,8 @@ namespace Ionic.Zip
                 ze.ArchiveStream.Seek(posn, SeekOrigin.Begin);
                 // workitem 10178
                 Ionic.Zip.SharedUtilities.Workaround_Ladybug318918(ze.ArchiveStream);
+
+                ze._LengthOfTrailer += ze._InputUsesZip64 ? 24 : 16;  // bytes including sig, CRC, Comp and Uncomp sizes
             }
 
             ze._CompressedFileDataSize = ze._CompressedSize;


### PR DESCRIPTION
Fix that sizeof ZipEntryDataDescriptorSignature may be added to _LengthOfTrailer more than once in rare case.