### PR TITLE
Added support for segment sizes over 2gb

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
-:minor: 11
+:minor: 12
 :patch: 0
 :special: ''
 :metadata: ''

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,16 +6,18 @@ GEM
       nokogiri (~> 1.5)
       rake (~> 10)
       semver2 (~> 3.4)
-    map (6.5.5)
-    mini_portile (0.6.0)
-    nokogiri (1.6.3.1)
-      mini_portile (= 0.6.0)
-    rake (10.3.2)
-    semver2 (3.4.0)
+    map (6.6.0)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.4-x64-mingw32)
+      mini_portile2 (~> 2.3.0)
+    rake (10.5.0)
+    semver2 (3.4.2)
 
 PLATFORMS
-  ruby
-  x86-mingw32
+  x64-mingw32
 
 DEPENDENCIES
   albacore (~> 2.0.0)
+
+BUNDLED WITH
+   1.16.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,11 +10,14 @@ GEM
     mini_portile2 (2.3.0)
     nokogiri (1.8.4-x64-mingw32)
       mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.4-x86-mingw32)
+      mini_portile2 (~> 2.3.0)
     rake (10.5.0)
     semver2 (3.4.2)
 
 PLATFORMS
   x64-mingw32
+  x86-mingw32
 
 DEPENDENCIES
   albacore (~> 2.0.0)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@
     except:
       - master
   install:
-  - gem install bundler --no-ri --no-rdoc
-  - bundle install
+  - C:\Ruby24-x64\bin\gem install bundler --no-ri --no-rdoc
+  - C:\Ruby24-x64\bin\bundle install
   build_script:
   - rake
   test: off
@@ -22,10 +22,10 @@
     only:
       - master
   install:
-  - gem install bundler --no-ri --no-rdoc
-  - bundle install
+  - C:\Ruby24-x64\bin\gem install bundler --no-ri --no-rdoc
+  - C:\Ruby24-x64\bin\bundle install
   build_script:
-  - rake
+  - C:\Ruby24-x64\bin\rake
   test: off
   artifacts:
   - path: build\pkg\*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@
   - gem install bundler --no-ri --no-rdoc
   - bundle install
   build_script:
-  - rake
+  - bundle exec rake
   test: off
   artifacts:
   - path: build\pkg\DotNetZip.*.nupkg
@@ -27,7 +27,7 @@
   - gem install bundler --no-ri --no-rdoc
   - bundle install
   build_script:
-  - rake
+  - bundle exec rake
   test: off
   artifacts:
   - path: build\pkg\*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,9 @@
     except:
       - master
   install:
-  - C:\Ruby24-x64\bin\gem install bundler --no-ri --no-rdoc
-  - C:\Ruby24-x64\bin\bundle install
+  - set PATH=C:\Ruby25\bin;%PATH%
+  - gem install bundler --no-ri --no-rdoc
+  - bundle install
   build_script:
   - rake
   test: off
@@ -22,10 +23,11 @@
     only:
       - master
   install:
-  - C:\Ruby24-x64\bin\gem install bundler --no-ri --no-rdoc
-  - C:\Ruby24-x64\bin\bundle install
+  - set PATH=C:\Ruby25\bin;%PATH%
+  - gem install bundler --no-ri --no-rdoc
+  - bundle install
   build_script:
-  - C:\Ruby24-x64\bin\rake
+  - rake
   test: off
   artifacts:
   - path: build\pkg\*.nupkg

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -2,6 +2,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-[assembly: AssemblyVersion("1.11.0")]
-[assembly: AssemblyFileVersion("1.11.0")]
-[assembly: AssemblyInformationalVersion("1.11.0.000000")]
+[assembly: AssemblyVersion("1.12.0")]
+[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyInformationalVersion("1.12.0.000000")]

--- a/src/Zip Tests/RandomBytesInputStream.cs
+++ b/src/Zip Tests/RandomBytesInputStream.cs
@@ -1,0 +1,126 @@
+﻿// RandomTextGenerator.cs
+// ------------------------------------------------------------------
+//
+// Copyright (c) 2009 Dino Chiesa
+// All rights reserved.
+//
+// This code module is part of DotNetZip, a zipfile class library.
+//
+// ------------------------------------------------------------------
+//
+// This code is licensed under the Microsoft Public License.
+// See the file License.txt for the license details.
+// More info on: http://dotnetzip.codeplex.com
+//
+// ------------------------------------------------------------------
+//
+// last saved (in emacs):
+// Time-stamp: <2011-July-13 16:37:19>
+//
+// ------------------------------------------------------------------
+//
+// This module defines a class that generates random byte sequences
+//
+// ------------------------------------------------------------------
+
+using System;
+using System.IO;
+
+namespace Ionic.Zip.Tests.Utilities
+{
+    public class RandomBytesInputStream : Stream
+    {
+        Int64 _desiredLength;
+        Int64 _bytesRead;
+        System.Random _rnd;
+
+        public RandomBytesInputStream(Int64 length)
+        {
+            _desiredLength = length;
+            _rnd = new System.Random();
+        }
+
+        new public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <summary>The Dispose method</summary>
+        protected override void Dispose(bool disposeManagedResources)
+        {
+        }
+
+        public Int64 BytesRead
+        {
+            get { return _bytesRead; }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (_desiredLength - _bytesRead < count)
+            {
+                int bytesToReadThisTime = unchecked((int)(_desiredLength - _bytesRead));
+                var buf = new byte[bytesToReadThisTime];
+                _rnd.NextBytes(buf);
+                Array.Copy(buf, buffer, bytesToReadThisTime);
+                _bytesRead += bytesToReadThisTime;
+                return bytesToReadThisTime;
+            }
+            else
+            {
+                _bytesRead += count;
+                _rnd.NextBytes(buffer);
+                return count;
+            }
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override bool CanRead
+        {
+            get { return true; }
+        }
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override long Length
+        {
+            get { return _desiredLength; }
+        }
+
+        public override long Position
+        {
+            get { return _desiredLength - _bytesRead; }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public override long Seek(long offset, System.IO.SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            if (value < _bytesRead)
+                throw new NotSupportedException();
+            _desiredLength = value;
+        }
+
+        public override void Flush()
+        {
+        }
+    }
+}

--- a/src/Zip Tests/Zip Tests.csproj
+++ b/src/Zip Tests/Zip Tests.csproj
@@ -72,8 +72,7 @@
     <Reference Include="Ionic.IO.JunctionPoint, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Zip.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\GAC\GAC_MSIL\Microsoft.VisualStudio.Zip.9.0\9.0.0.0__b03f5f7f11d50a3a\Microsoft.VisualStudio.Zip.9.0.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Zip.9.0.9.0\lib\Microsoft.VisualStudio.Zip.9.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -85,6 +84,7 @@
   <ItemGroup>
     <Compile Include="Compatibility.cs" />
     <Compile Include="ErrorTests.cs" />
+    <Compile Include="RandomBytesInputStream.cs" />
     <Compile Include="SplitArchives.cs" />
     <Compile Include="ExtendedTests.cs" />
     <Compile Include="LongRunning.cs" />
@@ -138,6 +138,7 @@
     <Content Include="Resources\Ionic.CopyData.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Include="packages.config" />
     <None Include="Resources\Ionic.IO.JunctionPoint.dll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Zip Tests/packages.config
+++ b/src/Zip Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.VisualStudio.Zip.9.0" version="9.0" targetFramework="net40" />
+</packages>

--- a/src/Zip.Shared/ZipEntry.Write.cs
+++ b/src/Zip.Shared/ZipEntry.Write.cs
@@ -189,7 +189,7 @@ namespace Ionic.Zip
 
             // Disk number start
             bool segmented = (this._container.ZipFile != null) &&
-                (this._container.ZipFile.MaxOutputSegmentSize != 0);
+                (this._container.ZipFile.MaxOutputSegmentSize64 != 0);
             if (segmented) // workitem 13915
             {
                 // Emit nonzero disknumber only if saving segmented archive.

--- a/src/Zip.Shared/ZipFile.Save.cs
+++ b/src/Zip.Shared/ZipFile.Save.cs
@@ -120,7 +120,7 @@ namespace Ionic.Zip
         /// </exception>
         ///
         /// <exception cref="System.OverflowException">
-        ///   Thrown if <see cref="MaxOutputSegmentSize"/> is non-zero, and the number
+        ///   Thrown if <see cref="MaxOutputSegmentSize"/> or <see cref="MaxOutputSegmentSize64"/> is non-zero, and the number
         ///   of segments that would be generated for the spanned zip file during the
         ///   save operation exceeds 99.  If this happens, you need to increase the
         ///   segment size.

--- a/src/Zip.Shared/ZipFile.cs
+++ b/src/Zip.Shared/ZipFile.cs
@@ -2026,6 +2026,10 @@ namespace Ionic.Zip
         /// </summary>
         /// <remarks>
         ///   <para>
+        ///     Make sure you do not read from this field if you've set the value using <see cref="MaxOutputSegmentSize64"/>
+        ///   </para>
+        ///   
+        ///   <para>
         ///     Set this to a non-zero value before calling <see cref="Save()"/> or <see
         ///     cref="Save(String)"/> to specify that the ZipFile should be saved as a
         ///     split archive, also sometimes called a spanned archive. Some also
@@ -2098,6 +2102,106 @@ namespace Ionic.Zip
         ///
         /// <seealso cref="NumberOfSegmentsForMostRecentSave"/>
         public Int32 MaxOutputSegmentSize
+        {
+            get
+            {
+                if(_maxOutputSegmentSize > Int32.MaxValue)
+                {
+                    throw new ZipException("MaxOutputSegmentSize is too large, use MaxOutputSegmentSize64 instead.");
+                }
+
+                return (Int32)_maxOutputSegmentSize;
+            }
+            set
+            {
+                if (value < 65536 && value != 0)
+                    throw new ZipException("The minimum acceptable segment size is 65536.");
+                _maxOutputSegmentSize = value;
+            }
+        }
+
+
+        /// <summary>
+        /// The maximum size of an output segment, when saving a split Zip file.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     If you set this value, make sure you do not accidently use <see cref="MaxOutputSegmentSize"/> in your code
+        ///   </para>
+        ///   
+        ///   <para>
+        ///     Set this to a non-zero value before calling <see cref="Save()"/> or <see
+        ///     cref="Save(String)"/> to specify that the ZipFile should be saved as a
+        ///     split archive, also sometimes called a spanned archive. Some also
+        ///     call them multi-file archives.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     A split zip archive is saved in a set of discrete filesystem files,
+        ///     rather than in a single file. This is handy when transmitting the
+        ///     archive in email or some other mechanism that has a limit to the size of
+        ///     each file.  The first file in a split archive will be named
+        ///     <c>basename.z01</c>, the second will be named <c>basename.z02</c>, and
+        ///     so on. The final file is named <c>basename.zip</c>. According to the zip
+        ///     specification from PKWare, the minimum value is 65536, for a 64k segment
+        ///     size. The maximum number of segments allows in a split archive is 99.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     The value of this property determines the maximum size of a split
+        ///     segment when writing a split archive.  For example, suppose you have a
+        ///     <c>ZipFile</c> that would save to a single file of 200k. If you set the
+        ///     <c>MaxOutputSegmentSize</c> to 65536 before calling <c>Save()</c>, you
+        ///     will get four distinct output files. On the other hand if you set this
+        ///     property to 256k, then you will get a single-file archive for that
+        ///     <c>ZipFile</c>.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     The size of each split output file will be as large as possible, up to
+        ///     the maximum size set here. The zip specification requires that some data
+        ///     fields in a zip archive may not span a split boundary, and an output
+        ///     segment may be smaller than the maximum if necessary to avoid that
+        ///     problem. Also, obviously the final segment of the archive may be smaller
+        ///     than the maximum segment size. Segments will never be larger than the
+        ///     value set with this property.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     You can save a split Zip file only when saving to a regular filesystem
+        ///     file. It's not possible to save a split zip file as a self-extracting
+        ///     archive, nor is it possible to save a split zip file to a stream. When
+        ///     saving to a SFX or to a Stream, this property is ignored.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     About interoperability: Split or spanned zip files produced by DotNetZip
+        ///     can be read by WinZip or PKZip, and vice-versa. Segmented zip files may
+        ///     not be readable by other tools, if those other tools don't support zip
+        ///     spanning or splitting.  When in doubt, test.  I don't believe Windows
+        ///     Explorer can extract a split archive.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     This property has no effect when reading a split archive. You can read
+        ///     a split archive in the normal way with DotNetZip.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     When saving a zip file, if you want a regular zip file rather than a
+        ///     split zip file, don't set this property, or set it to Zero.
+        ///   </para>
+        ///
+        ///   <para>
+        ///     If you read a split archive, with <see cref="ZipFile.Read(string)"/> and
+        ///     then subsequently call <c>ZipFile.Save()</c>, unless you set this
+        ///     property before calling <c>Save()</c>, you will get a normal,
+        ///     single-file archive.
+        ///   </para>
+        /// </remarks>
+        ///
+        /// <seealso cref="NumberOfSegmentsForMostRecentSave"/>
+        public Int64 MaxOutputSegmentSize64
         {
             get
             {
@@ -3655,7 +3759,7 @@ namespace Ionic.Zip
         private UInt16 _versionMadeBy;
         private UInt16 _versionNeededToExtract;
         private UInt32 _diskNumberWithCd;
-        private Int32 _maxOutputSegmentSize;
+        private Int64 _maxOutputSegmentSize;
         private UInt32 _numberOfSegmentsForMostRecentSave;
         private ZipErrorAction _zipErrorAction;
         private bool _disposed;

--- a/src/Zip.Shared/ZipSegmentedStream.cs
+++ b/src/Zip.Shared/ZipSegmentedStream.cs
@@ -49,7 +49,7 @@ namespace Ionic.Zip
         private string _currentTempName;
         private uint _currentDiskNumber;
         private uint _maxDiskNumber;
-        private int _maxSegmentSize;
+        private long _maxSegmentSize;
         private System.IO.Stream _innerStream;
 
         // **Note regarding exceptions:
@@ -89,7 +89,7 @@ namespace Ionic.Zip
         }
 
 
-        public static ZipSegmentedStream ForWriting(string name, int maxSegmentSize)
+        public static ZipSegmentedStream ForWriting(string name, long maxSegmentSize)
         {
             ZipSegmentedStream zss = new ZipSegmentedStream()
                 {
@@ -357,11 +357,22 @@ namespace Ionic.Zip
             {
                 while (_innerStream.Position + count > _maxSegmentSize)
                 {
-                    int c = unchecked(_maxSegmentSize - (int)_innerStream.Position);
-                    _innerStream.Write(buffer, offset, c);
+                    long c = _maxSegmentSize - _innerStream.Position;
+                    int cnt;
+                    if (c > buffer.Length)
+                    {
+                        cnt = buffer.Length;
+                    }
+                    else
+                    {
+                        cnt = (int)c;
+                    }
+
+                    _innerStream.Write(buffer, offset, cnt);
+
                     _SetWriteStream(1);
-                    count -= c;
-                    offset += c;
+                    count -= cnt;
+                    offset += cnt;
                 }
             }
 

--- a/src/Zip.Shared/ZipSegmentedStream.cs
+++ b/src/Zip.Shared/ZipSegmentedStream.cs
@@ -88,6 +88,10 @@ namespace Ionic.Zip
             return zss;
         }
 
+        public static ZipSegmentedStream ForWriting(string name, int maxSegmentSize)
+        {
+            return ForWriting(name, (long)maxSegmentSize);
+        }
 
         public static ZipSegmentedStream ForWriting(string name, long maxSegmentSize)
         {


### PR DESCRIPTION
Hello everyone.

I've ran into limitation that max segment size variable is int32, thus the max value is 2gb, which is less than I require. To overcome this issue I've added a 64bit (long) variable alongside the existing one and changed related non-public code to use long instead of int.
I've also added component test to make sure that my changes do not break stuff.