### PR TITLE
Fix AppVeyor Build gem install tls error.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
       - master
   install:
   - ps: |
-      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   - set PATH=C:\Ruby25\bin;%PATH%
   - gem install bundler --no-ri --no-rdoc
   - bundle install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@
     except:
       - master
   install:
+  - set PATH=C:\Ruby25\bin;%PATH%
   - gem install bundler --no-ri --no-rdoc
   - bundle install
   build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@
     except:
       - master
   install:
+  - ps: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls
   - set PATH=C:\Ruby25\bin;%PATH%
   - gem install bundler --no-ri --no-rdoc
   - bundle install


### PR DESCRIPTION
Attempting to see if a newer version of Ruby being forced with resolve errors in using TLS v1. #141 