### PR TITLE
Fixes for the .NET Standard build

### DIFF
--- a/src/Zip NetStandard/Zip NetStandard.csproj
+++ b/src/Zip NetStandard/Zip NetStandard.csproj
@@ -12,6 +12,10 @@
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <DefineConstants>AESCRYPTO;BZIP</DefineConstants>
+    </PropertyGroup>
+
     <ItemGroup>
         <Compile Include="..\BZip2\BitWriter.cs" Link="BZip2\BitWriter.cs" />
         <Compile Include="..\BZip2\BZip2Compressor.cs" Link="BZip2\BZip2Compressor.cs" />

--- a/src/Zip NetStandard/Zip NetStandard.csproj
+++ b/src/Zip NetStandard/Zip NetStandard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
@@ -23,6 +23,10 @@
 
     <ItemGroup>
         <Folder Include="BZip2\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
     </ItemGroup>
 
     <Import Project="..\Zlib.Shared\Zlib.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
Two changes for the .NET Standard project:

1) Include SolutionInfo.cs in the project to pick up the version number (#152)
2) Add AESCRYPTO and BZIP to the defines to match the .NET 4 project

(2) seems to be required to enable AES encryption support in the Standard build.