### PR TITLE
sign the .NET Standard asembly with Ionic.snk

### DIFF
--- a/src/Zip NetStandard/Zip NetStandard.csproj
+++ b/src/Zip NetStandard/Zip NetStandard.csproj
@@ -14,6 +14,9 @@
 
     <PropertyGroup>
       <DefineConstants>AESCRYPTO;BZIP</DefineConstants>
+      <SignAssembly>true</SignAssembly>
+      <AssemblyOriginatorKeyFile>..\Ionic.snk</AssemblyOriginatorKeyFile>
+      <DelaySign>false</DelaySign>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The .NET 4.0 version of the assembly is strong named, so perhaps the .NET Standard version should be as well.