### PR TITLE
Bump version so a fixed nuget package can be released

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
 :minor: 13
-:patch: 0
+:patch: 1
 :special: ''
 :metadata: ''

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -1,4 +1,3 @@
-
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -2,6 +2,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-[assembly: AssemblyVersion("1.13.0")]
-[assembly: AssemblyFileVersion("1.13.0")]
-[assembly: AssemblyInformationalVersion("1.13.0.000000")]
+[assembly: AssemblyVersion("1.13.1")]
+[assembly: AssemblyFileVersion("1.13.1")]
+[assembly: AssemblyInformationalVersion("1.13.1.000000")]


### PR DESCRIPTION
I'm running into assembly loading errors due to https://github.com/haf/DotNetZip.Semverd/issues/152; the fix is apparently already in master thanks to https://github.com/haf/DotNetZip.Semverd/pull/154, but there's not new version on nuget yet.

Could you push the fixed version to nuget?