### PR TITLE
Fix some unit tests that were referring to no-longer-created files

### DIFF
--- a/src/Zip Tests/Compatibility.cs
+++ b/src/Zip Tests/Compatibility.cs
@@ -78,7 +78,7 @@ namespace Ionic.Zip.Tests
             for (int i = 0; i < 3; i++)
                 SourceDir = Path.GetDirectoryName(SourceDir);
 
-            IonicZipDll = Path.Combine(SourceDir, "Zip\\bin\\Debug\\Ionic.Zip.dll");
+            IonicZipDll = Path.Combine(SourceDir, "Zip\\bin\\Debug\\DotNetZip.dll");
 
             Assert.IsTrue(File.Exists(IonicZipDll), "DLL ({0}) does not exist", IonicZipDll);
 

--- a/src/Zip Tests/ErrorTests.cs
+++ b/src/Zip Tests/ErrorTests.cs
@@ -278,7 +278,7 @@ namespace Ionic.Zip.Tests.Error
             string[] fileNames =
                 {
                     Path.Combine(sourceDir, "Tools\\Zipit\\bin\\Debug\\Zipit.exe"),
-                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\Ionic.Zip.xml"),
+                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\DotNetZip.xml"),
                     Path.Combine(sourceDir, "Tools\\WinFormsApp\\Icon2.res"),
                 };
 
@@ -620,7 +620,7 @@ namespace Ionic.Zip.Tests.Error
             string[] filenames =
             {
                 Path.Combine(sourceDir, "Tools\\Zipit\\bin\\Debug\\Zipit.exe"),
-                Path.Combine(sourceDir, "Zip\\bin\\Debug\\Ionic.Zip.xml"),
+                Path.Combine(sourceDir, "Zip\\bin\\Debug\\DotNetZip.xml"),
                 Path.Combine(sourceDir, "Tools\\WinFormsApp\\Icon2.res"),
             };
 
@@ -683,7 +683,7 @@ namespace Ionic.Zip.Tests.Error
             {
                 Path.Combine(sourceDir, "Tools\\Zipit\\bin\\Debug\\Zipit.exe"),
                 Path.Combine(sourceDir, "Tools\\Unzip\\bin\\Debug\\Unzip.exe"),
-                Path.Combine(sourceDir, "Zip\\bin\\Debug\\Ionic.Zip.xml"),
+                Path.Combine(sourceDir, "Zip\\bin\\Debug\\DotNetZip.xml"),
                 Path.Combine(sourceDir, "Tools\\WinFormsApp\\Icon2.res"),
             };
 

--- a/src/Zip Tests/ExtendedTests.cs
+++ b/src/Zip Tests/ExtendedTests.cs
@@ -1411,9 +1411,9 @@ namespace Ionic.Zip.Tests.Extended
             string[] filenames =
                 {
                     Path.Combine(sourceDir, "Tools\\Zipit\\bin\\Debug\\Zipit.exe"),
-                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\Ionic.Zip.dll"),
-                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\Ionic.Zip.pdb"),
-                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\Ionic.Zip.xml"),
+                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\DotNetZip.dll"),
+                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\DotNetZip.pdb"),
+                    Path.Combine(sourceDir, "Zip\\bin\\Debug\\DotNetZip.xml"),
                     //Path.Combine(SourceDir, "AppNote.txt")
                 };
 
@@ -1592,7 +1592,7 @@ namespace Ionic.Zip.Tests.Extended
                 "testing a zip library so challenging. " ;
 
             string testBin = TestUtilities.GetTestBinDir(CurrentDir);
-            string fileToZip = Path.Combine(testBin, "Ionic.Zip.dll");
+            string fileToZip = Path.Combine(testBin, "DotNetZip.dll");
 
             for (int i = 0; i < crypto.Length; i++)
             {

--- a/src/Zip Tests/PasswordTests.cs
+++ b/src/Zip Tests/PasswordTests.cs
@@ -299,7 +299,7 @@ namespace Ionic.Zip.Tests.Password
             string[] filenames =
             {
                 Path.Combine(SourceDir, "Tools\\Zipit\\bin\\Debug\\Zipit.exe"),
-                Path.Combine(SourceDir, "Zip\\bin\\Debug\\Ionic.Zip.xml"),
+                Path.Combine(SourceDir, "Zip\\bin\\Debug\\DotNetZip.xml"),
             };
 
             string[] checksums =
@@ -357,7 +357,7 @@ namespace Ionic.Zip.Tests.Password
             string[] filenames =
             {
                 Path.Combine(SourceDir, "Tools\\Zipit\\bin\\Debug\\Zipit.exe"),
-                Path.Combine(SourceDir, "Zip\\bin\\Debug\\Ionic.Zip.xml"),
+                Path.Combine(SourceDir, "Zip\\bin\\Debug\\DotNetZip.xml"),
             };
 
             string[] passwords =
@@ -397,7 +397,7 @@ namespace Ionic.Zip.Tests.Password
             string[] filenames =
             {
                 Path.Combine(dnzDir, "Tools\\Zipit\\bin\\Debug\\Zipit.exe"),
-                Path.Combine(dnzDir, "Zip\\bin\\Debug\\Ionic.Zip.xml"),
+                Path.Combine(dnzDir, "Zip\\bin\\Debug\\DotNetZip.xml"),
             };
 
             string[] checksums =

--- a/src/Zip Tests/Streams.cs
+++ b/src/Zip Tests/Streams.cs
@@ -1867,7 +1867,7 @@ namespace Ionic.Zip.Tests.Streams
             string aspxPage = Path.Combine(resourceDir, "GenerateZip-cs.aspx");
             Assert.IsTrue(File.Exists(aspxPage));
 
-            string ionicZipDll = Path.Combine(testBin, "Ionic.Zip.dll");
+            string ionicZipDll = Path.Combine(testBin, "DotNetZip.dll");
             string loremFile = "LoremIpsum.txt";
 
             Action<String> copyToBin = (x) =>

--- a/src/Zip Tests/Zip64Tests.cs
+++ b/src/Zip Tests/Zip64Tests.cs
@@ -951,7 +951,7 @@ namespace Ionic.Zip.Tests.Zip64
         public void Zip64_Winzip_Unzip_OneFile()
         {
             string testBin = TestUtilities.GetTestBinDir(CurrentDir);
-            string fileToZip = Path.Combine(testBin, "Ionic.Zip.dll");
+            string fileToZip = Path.Combine(testBin, "DotNetZip.dll");
 
             Directory.SetCurrentDirectory(TopLevelDir);
 


### PR DESCRIPTION
Looks like some of the unit tests fail because they try to use Ionic.Zip.(dll/pdb) as input to tests and those no longer exist. Change them to use DotNetZip.(dll/pdb) instead