### PR TITLE
[#160] In WinZipAesCipherStream, create the AES instance using 'Aes.Create()…

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
 :minor: 13
-:patch: 2
+:patch: 3
 :special: ''
 :metadata: ''

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-[assembly: AssemblyVersion("1.13.2")]
-[assembly: AssemblyFileVersion("1.13.2")]
-[assembly: AssemblyInformationalVersion("1.13.2.000000")]
+[assembly: AssemblyVersion("1.13.3")]
+[assembly: AssemblyFileVersion("1.13.3")]
+[assembly: AssemblyInformationalVersion("1.13.3.000000")]

--- a/src/Zip.Shared/WinZipAes.cs
+++ b/src/Zip.Shared/WinZipAes.cs
@@ -356,7 +356,7 @@ namespace Ionic.Zip
 
         internal HMACSHA1 _mac;
 
-        internal AesManaged _aesCipher;
+        internal Aes _aesCipher;
         internal ICryptoTransform _xform;
 
         private const int BLOCK_SIZE_IN_BYTES = 16;
@@ -428,7 +428,7 @@ namespace Ionic.Zip
 
             _mac = new HMACSHA1(_params.MacIv);
 
-            _aesCipher = new System.Security.Cryptography.AesManaged();
+            _aesCipher = System.Security.Cryptography.Aes.Create();
             _aesCipher.BlockSize = 128;
             _aesCipher.KeySize = keySizeInBits;  // 128, 192, 256
             _aesCipher.Mode = CipherMode.ECB;
@@ -834,6 +834,9 @@ namespace Ionic.Zip
                 _pendingCount = 0;
             }
             _s.Close();
+
+            _xform.Dispose();
+            _aesCipher.Dispose();
 
 #if WANT_TRACE
             untransformed.Close();


### PR DESCRIPTION
…' instead of 'new AesManaged()'

Enables it to use newer algorithms/implementations where available, which helps in enviroments where AesManaged isn't useable.