### PR TITLE
Change appveyor.yml to use gem install --no-document rather than gem install --no-ri --no-rdoc

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
       - master
   install:
   - set PATH=C:\Ruby25\bin;%PATH%
-  - gem install bundler --no-ri --no-rdoc
+  - gem install bundler --no-document
   - bundle install
   build_script:
   - bundle exec rake
@@ -24,7 +24,7 @@
       - master
   install:
   - set PATH=C:\Ruby25\bin;%PATH%
-  - gem install bundler --no-ri --no-rdoc
+  - gem install bundler --no-document
   - bundle install
   build_script:
   - bundle exec rake


### PR DESCRIPTION
The gem --no-ri option seems to be removed in new gem versions, so try using --no-document instead