### PR TITLE
Change: Allow the ZLib dictionary state to be set unconditionally

### DIFF
--- a/src/Zlib.Shared/Inflate.cs
+++ b/src/Zlib.Shared/Inflate.cs
@@ -1698,16 +1698,22 @@ namespace Ionic.Zlib
 
 
 
-        internal int SetDictionary(byte[] dictionary)
+        internal int SetDictionary(byte[] dictionary, bool unconditional = false)
         {
             int index = 0;
             int length = dictionary.Length;
-            if (mode != InflateManagerMode.DICT0)
-                throw new ZlibException("Stream error.");
-
-            if (Adler.Adler32(1, dictionary, 0, dictionary.Length) != _codec._Adler32)
+            //MSZip requires the dictionary to be set unconditionally
+            if (unconditional == false)
             {
-                return ZlibConstants.Z_DATA_ERROR;
+                if (mode != InflateManagerMode.DICT0)
+                {
+                    throw new ZlibException("Stream error.");
+                }
+
+                if (Adler.Adler32(1, dictionary, 0, dictionary.Length) != _codec._Adler32)
+                {
+                    return ZlibConstants.Z_DATA_ERROR;
+                }
             }
 
             _codec._Adler32 = Adler.Adler32(0, null, 0, 0);

--- a/src/Zlib.Shared/ZlibCodec.cs
+++ b/src/Zlib.Shared/ZlibCodec.cs
@@ -652,6 +652,24 @@ namespace Ionic.Zlib
             throw new ZlibException("No Inflate or Deflate state!");
         }
 
+        /// <summary>
+        /// Set the dictionary to be used for either Inflation or Deflation unconditionally.
+        /// </summary>
+        /// <remarks>Decoding a MSZip file requires the dictionary state to be set unconditionally
+        /// at the end of each block to the previous decoded data</remarks>
+        /// <param name="dictionary">The dictionary bytes to use.</param>
+        /// <returns>Z_OK if all goes well.</returns>
+        public int SetDictionaryUnconditionally(byte[] dictionary)
+        {
+            if (istate != null)
+                return istate.SetDictionary(dictionary, true);
+
+            if (dstate != null)
+                return dstate.SetDictionary(dictionary);
+
+            throw new ZlibException("No Inflate or Deflate state!");
+        }
+
         // Flush as much pending output as possible. All deflate() output goes
         // through this function so some applications may wish to modify it
         // to avoid allocating a large strm->next_out buffer and copying into it.


### PR DESCRIPTION
In order to decode a MSZip file, it requires the ZLib dictionary to be unconditionally set to the previously decoded bytes at the end of each block.

Unfortunately, there is *no* error checking whatsoever involved in this, and it'll quite happily decode garbage data if you do not do this.
This makes it pretty much impossible to implement a sensible working unit test.

Some background and a file in this issue, although this is a MSZip compressed binary X object:
https://github.com/leezer3/OpenBVE/issues/289

I suppose I could hash stream and hash the output if you want?

### Implementation Notes:
- This adds an additional method to unconditionally set the dictionary state. MSZip files are uncommon at best, and the error checking is probably useful.
- I was previously using a locally built copy of Ionic.Zlib (1.12.0), which appears to have allowed the dictionary state to be set unconditionally. Your source history doesn't show any changes in the ZlibCodec, so I have no rationale as to why this was actually changed at your end?