### PR TITLE
Ignore duplicates 2

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
 :minor: 13
-:patch: 4
+:patch: 5
 :special: ''
 :metadata: ''

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-[assembly: AssemblyVersion("1.13.4")]
-[assembly: AssemblyFileVersion("1.13.4")]
-[assembly: AssemblyInformationalVersion("1.13.4.000000")]
+[assembly: AssemblyVersion("1.13.5")]
+[assembly: AssemblyFileVersion("1.13.5")]
+[assembly: AssemblyInformationalVersion("1.13.5.000000")]

--- a/src/Zip.Shared/ZipFile.Read.cs
+++ b/src/Zip.Shared/ZipFile.Read.cs
@@ -783,9 +783,12 @@ namespace Ionic.Zip
                 if (zf.Verbose)
                     zf.StatusMessageTextWriter.WriteLine("  {0}", e.FileName);
 
-                zf._entries.Add(e.FileName,e);
-                if (!zf._entriesInsensitive.ContainsKey(e.FileName))
-                    zf._entriesInsensitive.Add(e.FileName,e);
+                if (!(zf.IgnoreDuplicateFiles && zf._entries.ContainsKey(e.FileName)))
+                {
+                    zf._entries.Add(e.FileName,e);
+                    if (!zf._entriesInsensitive.ContainsKey(e.FileName))
+                        zf._entriesInsensitive.Add(e.FileName,e);
+                }
                 firstEntry = false;
             }
 


### PR DESCRIPTION
Fixes another case where duplicated files in externally-created zips could cause an exception on read.