### PR TITLE
fixed O(N²) Performance Bug 

### DIFF
--- a/src/Zip.Shared/ZipFile.cs
+++ b/src/Zip.Shared/ZipFile.cs
@@ -2485,10 +2485,10 @@ namespace Ionic.Zip
                     // cannot just replace the entries - the app may be holding them
                     foreach (ZipEntry e1 in x)
                     {
-						var e2 = this[e1.FileName];
-						if (e2 != null && !e2.IsChanged)
+                        var e2 = this[e1.FileName];
+                        if (e2 != null && !e2.IsChanged)
                         {
-							e2.CopyMetaData(e1);
+                            e2.CopyMetaData(e1);
                         }
                     }
                 }


### PR DESCRIPTION
Dictionary Lookup is faster: O(1)
This Bug makes Operations really slow when the Number of Files exceeds 25000. 
