### PR TITLE
Repair leap year bugs in unit test

### DIFF
--- a/src/Zip Tests/Selector.cs
+++ b/src/Zip Tests/Selector.cs
@@ -53,7 +53,7 @@ namespace Ionic.Zip.Tests
             tomorrow = todayAtMidnight + new TimeSpan(1, 0, 0, 0);
             threeDaysAgo = todayAtMidnight - new TimeSpan(3, 0, 0, 0);
             twoDaysAgo = todayAtMidnight - new TimeSpan(2, 0, 0, 0);
-            threeYearsAgo = new DateTime(DateTime.Now.Year - 3, DateTime.Now.Month, DateTime.Now.Day);
+            threeYearsAgo = todayAtMidnight.AddYears(-3);
 
             oneDay = new TimeSpan(1,0,0,0);
             yesterdayAtMidnight = todayAtMidnight - oneDay;
@@ -967,9 +967,7 @@ namespace Ionic.Zip.Tests
 
                 // None of the files should have been created
                 // more than 20 years ago
-                var twentyYearsAgo = new DateTime(DateTime.Now.Year - 20,
-                                                  DateTime.Now.Month,
-                                                  DateTime.Now.Day);
+                var twentyYearsAgo = todayAtMidnight.AddYears(-20);
                 crit = String.Format("ctime < {0}",
                                      twentyYearsAgo.ToString("yyyy-MM-dd"));
                 var selected5 = zip1.SelectEntries(crit);


### PR DESCRIPTION
On `2020-02-29`, the `DateTime` constructor creating the `threeYearsAgo` variable will attempt to create `2017-02-29`, which doesn't exist since 2017 was not a leap year.  The result is an `ArgumentOutOfRangeException`.

I also fixed a similar occurrence of this pattern in the `twentyYearsAgo` variable construction, though it won't throw since 2000 was indeed a leap year.

See also https://aka.ms/leapday2020blog