### PR TITLE
Added parsing of Disk Start Number from Zip64 header if available

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
 :minor: 13
-:patch: 6
+:patch: 7
 :special: ''
 :metadata: ''

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-[assembly: AssemblyVersion("1.13.6")]
-[assembly: AssemblyFileVersion("1.13.6")]
-[assembly: AssemblyInformationalVersion("1.13.6.000000")]
+[assembly: AssemblyVersion("1.13.7")]
+[assembly: AssemblyFileVersion("1.13.7")]
+[assembly: AssemblyInformationalVersion("1.13.7.000000")]

--- a/src/Zip Tests/Zip64Tests.cs
+++ b/src/Zip Tests/Zip64Tests.cs
@@ -1251,7 +1251,24 @@ namespace Ionic.Zip.Tests.Zip64
             System.Threading.Thread.Sleep(120);
         }
 
+        [TestMethod]
+        public void Zip64_ExtractZip64Archives()
+        {
+            File.Delete(@"C:\tmp\test.zip");
+            File.WriteAllText(@"C:\tmp\content.txt", "someContent");
 
+            using (ZipFile zipFile = new ZipFile(@"C:\tmp\test.zip"))
+            {
+                zipFile.AddFile(@"C:\tmp\content.txt");
+
+                zipFile.UseZip64WhenSaving = Zip64Option.Always;
+                zipFile.MaxOutputSegmentSize = 700 * 984540;
+                zipFile.Save();
+            }
+
+            var extractedZipFile = ZipFile.Read(@"C:\tmp\test.zip");
+            extractedZipFile.ExtractAll(@"C:\tmp\extracted", ExtractExistingFileAction.OverwriteSilently);
+        }
 
         [TestMethod, Timeout((int)(2 * 60*60*1000))] // 60*60*1000 = 1 hr
         public void Zip64_Winzip_Setup()


### PR DESCRIPTION
This PR fixes an issue reported in #194 - this was happening a the result of 2 problems:

1. My recent PR #184 with a 'proper' (7-zip and WinZip friendly) way of writing Zip64 header, which have set Disk Start Number in Local & Central entry headers to 0xFFFF and populated the proper value to Zip64, have introduced an incompatibility of DotNetZip-generated zips with DotNetZip itself. 😄
2. Turned out we've never actually supported Disk Start Number in Zip64 header, the comment there stated that we don't support spanning zips, but actually we do

So... I've added the support for Disk Start Number in Zip64 header, it will only be used if it's available (to support more 'exotic' tools than WinZip) and if the Local/Central entry Disk Start Number was 0xFFFF (as prescribed by PKWARE spec).

I've tested my change with non-spanning zip case (new test) and spanning zip case - both can be read by DotNetZip just fine now.