### PR TITLE
Fix non-ordinal string comparison.

### DIFF
--- a/src/Zip Tests/ExtendedTests.cs
+++ b/src/Zip Tests/ExtendedTests.cs
@@ -341,10 +341,32 @@ namespace Ionic.Zip.Tests.Extended
             }
         }
 
+        [TestMethod]
+        public void ReadZip_DirectoryBitNotSetForFileWithEmojiName()
+        {
+            string zipFileToCreate = Path.Combine(TopLevelDir, "ReadZip_DirectoryBitNotSetForFileWithEmojiName.zip");
+            string entryName = "Files/\u26BE";
 
+            using (ZipFile zip1 = new ZipFile(Encoding.UTF8))
+            {
+                zip1.AddEntry(entryName, new byte[0]);
 
+                ZipEntry entry = zip1[entryName];
+                Assert.AreNotEqual(null, entry);
+                Assert.IsFalse(entry.IsDirectory,
+                               "The IsDirectory property was not set as expected.");
 
+                zip1.Save(zipFileToCreate);
+            }
 
+            using (ZipFile zip2 = ZipFile.Read(zipFileToCreate))
+            {
+                ZipEntry entry = zip2[entryName];
+                Assert.AreNotEqual(null, entry);
+                Assert.IsFalse(entry.IsDirectory,
+                               "The IsDirectory property was not set as expected.");
+            }
+        }
 
         [TestMethod]
         public void ReadZip_DirectoryBitSetForEmptyDirectories()

--- a/src/Zip.Shared/Shared.cs
+++ b/src/Zip.Shared/Shared.cs
@@ -92,7 +92,7 @@ namespace Ionic.Zip
         internal static string NormalizePath(string path)
         {
             // remove leading single dot slash
-            if (path.StartsWith(".\\")) path = path.Substring(2);
+            if (path.StartsWith(".\\", StringComparison.Ordinal)) path = path.Substring(2);
 
             // remove intervening dot-slash
             path = path.Replace("\\.\\", "\\");
@@ -109,7 +109,7 @@ namespace Ionic.Zip
 
         private static string SimplifyFwdSlashPath(string path)
         {
-            if (path.StartsWith("./")) path = path.Substring(2);
+            if (path.StartsWith("./", StringComparison.Ordinal)) path = path.Substring(2);
             path = path.Replace("/./", "/");
 
             // Replace foo/anything/../bar with foo/bar
@@ -138,7 +138,7 @@ namespace Ionic.Zip
             pathName = pathName.Replace('\\', '/');
 
             // trim all leading slashes
-            while (pathName.StartsWith("/")) pathName = pathName.Substring(1);
+            while (pathName.StartsWith("/", StringComparison.Ordinal)) pathName = pathName.Substring(1);
 
             return SimplifyFwdSlashPath(pathName);
         }

--- a/src/Zip.Shared/ZipDirEntry.cs
+++ b/src/Zip.Shared/ZipDirEntry.cs
@@ -288,7 +288,7 @@ namespace Ionic.Zip
                 if (zde.AttributesIndicateDirectory)
                     zde.MarkAsDirectory();  // may append a slash to filename if nec.
                     // workitem 6898
-                else if (zde._FileNameInArchive.EndsWith("/")) zde.MarkAsDirectory();
+                else if (zde._FileNameInArchive.EndsWith("/", StringComparison.Ordinal)) zde.MarkAsDirectory();
 
                 zde._CompressedFileDataSize = zde._CompressedSize;
                 if ((zde._BitField & 0x01) == 0x01)

--- a/src/Zip.Shared/ZipEntry.Extract.cs
+++ b/src/Zip.Shared/ZipEntry.Extract.cs
@@ -1375,7 +1375,7 @@ namespace Ionic.Zip
             if (f.IndexOf(':') == 1)
                 f = f.Substring(2);
 
-            if (f.StartsWith("/"))
+            if (f.StartsWith("/", StringComparison.Ordinal))
                 f = f.Substring(1);
 
             f = SharedUtilities.SanitizePath(f);
@@ -1388,7 +1388,7 @@ namespace Ionic.Zip
             outFileName = outFileName.Replace('/', Path.DirectorySeparatorChar);
 
             // check if it is a directory
-            if (IsDirectory || FileName.EndsWith("/"))
+            if (IsDirectory || FileName.EndsWith("/", StringComparison.Ordinal))
             {
                 if (!Directory.Exists(outFileName))
                 {
@@ -1412,7 +1412,7 @@ namespace Ionic.Zip
         /// </summary>
         bool IsDoneWithOutputToStream()
         {
-            return IsDirectory || FileName.EndsWith("/");
+            return IsDirectory || FileName.EndsWith("/", StringComparison.Ordinal);
         }
 
         #endregion

--- a/src/Zip.Shared/ZipEntry.Read.cs
+++ b/src/Zip.Shared/ZipEntry.Read.cs
@@ -141,7 +141,7 @@ namespace Ionic.Zip
             ze._FileNameInArchive = ze.AlternateEncoding.GetString(block);
 
             // workitem 6898
-            if (ze._FileNameInArchive.EndsWith("/")) ze.MarkAsDirectory();
+            if (ze._FileNameInArchive.EndsWith("/", StringComparison.Ordinal)) ze.MarkAsDirectory();
 
             bytesRead += ze.ProcessExtraField(ze.ArchiveStream, extraFieldLength);
 
@@ -149,7 +149,7 @@ namespace Ionic.Zip
 
             // workitem 6607 - don't read for directories
             // actually get the compressed size and CRC if necessary
-            if (!ze._FileNameInArchive.EndsWith("/") && (ze._BitField & 0x0008) == 0x0008)
+            if (!ze._IsDirectory && (ze._BitField & 0x0008) == 0x0008)
             {
                 // This descriptor exists only if bit 3 of the general
                 // purpose bit flag is set (see below).  It is byte aligned

--- a/src/Zip.Shared/ZipEntry.Write.cs
+++ b/src/Zip.Shared/ZipEntry.Write.cs
@@ -2461,7 +2461,7 @@ namespace Ionic.Zip
             WriteHeader(outstream, 0);
             StoreRelativeOffset();
 
-            if (!this.FileName.EndsWith("/"))
+            if (!this.FileName.EndsWith("/", StringComparison.Ordinal))
             {
                 // Not a directory; there is file data.
                 // Seek to the beginning of the entry data in the input stream.

--- a/src/Zip.Shared/ZipEntry.cs
+++ b/src/Zip.Shared/ZipEntry.cs
@@ -2504,7 +2504,7 @@ namespace Ionic.Zip
         {
             _IsDirectory = true;
             // workitem 6279
-            if (!_FileNameInArchive.EndsWith("/"))
+            if (!_FileNameInArchive.EndsWith("/", StringComparison.Ordinal))
                 _FileNameInArchive += "/";
         }
 

--- a/src/Zip.Shared/ZipFile.Extract.cs
+++ b/src/Zip.Shared/ZipFile.Extract.cs
@@ -273,9 +273,9 @@ namespace Ionic.Zip
                     foreach (ZipEntry e in _entries.Values)
                     {
                         // check if it is a directory
-                        if ((e.IsDirectory) || (e.FileName.EndsWith("/")))
+                        if ((e.IsDirectory) || (e.FileName.EndsWith("/", StringComparison.Ordinal)))
                         {
-                            string outputFile = (e.FileName.StartsWith("/"))
+                            string outputFile = (e.FileName.StartsWith("/", StringComparison.Ordinal))
                                 ? Path.Combine(path, e.FileName.Substring(1))
                                 : Path.Combine(path, e.FileName);
 

--- a/src/Zip.Shared/ZipFile.Selector.cs
+++ b/src/Zip.Shared/ZipFile.Selector.cs
@@ -638,7 +638,7 @@ namespace Ionic.Zip
 
         private string EnsureendInSlash(string s)
         {
-            if (s.EndsWith("\\")) return s;
+            if (s.EndsWith("\\", StringComparison.Ordinal)) return s;
             return s + "\\";
         }
 
@@ -659,7 +659,7 @@ namespace Ionic.Zip
             }
 
             // workitem 9176
-            while (directoryOnDisk.EndsWith("\\")) directoryOnDisk = directoryOnDisk.Substring(0, directoryOnDisk.Length - 1);
+            while (directoryOnDisk.EndsWith("\\", StringComparison.Ordinal)) directoryOnDisk = directoryOnDisk.Substring(0, directoryOnDisk.Length - 1);
             if (Verbose) StatusMessageTextWriter.WriteLine("adding selection '{0}' from dir '{1}'...",
                                                                selectionCriteria, directoryOnDisk);
             Ionic.FileSelector ff = new Ionic.FileSelector(selectionCriteria,
@@ -1444,7 +1444,7 @@ namespace Ionic
             // workitem 9174
             if (slashSwapped != null)
             {
-                while (slashSwapped.EndsWith("\\"))
+                while (slashSwapped.EndsWith("\\", StringComparison.Ordinal))
                     slashSwapped = slashSwapped.Substring(0, slashSwapped.Length - 1);
             }
             foreach (Ionic.Zip.ZipEntry e in zip)

--- a/src/Zip.Shared/ZipFile.cs
+++ b/src/Zip.Shared/ZipFile.cs
@@ -3160,7 +3160,7 @@ namespace Ionic.Zip
                         if (e.FileName.Replace("\\", "/") == fileName) return e;
 
                         // check for a difference only in trailing slash
-                        if (e.FileName.EndsWith("/"))
+                        if (e.FileName.EndsWith("/", StringComparison.Ordinal))
                         {
                             var fileNameNoSlash = e.FileName.Trim("/".ToCharArray());
                             if (fileNameNoSlash == fileName) return e;
@@ -3179,7 +3179,7 @@ namespace Ionic.Zip
                         if (String.Compare(e.FileName.Replace("\\", "/"), fileName, StringComparison.CurrentCultureIgnoreCase) == 0) return e;
 
                         // check for a difference only in trailing slash
-                        if (e.FileName.EndsWith("/"))
+                        if (e.FileName.EndsWith("/", StringComparison.Ordinal))
                         {
                             var fileNameNoSlash = e.FileName.Trim("/".ToCharArray());
 

--- a/src/Zip.Shared/ZipOutputStream.cs
+++ b/src/Zip.Shared/ZipOutputStream.cs
@@ -1391,7 +1391,7 @@ namespace Ionic.Zip
             _currentEntry.AlternateEncoding = this.AlternateEncoding;
             _currentEntry.AlternateEncodingUsage = this.AlternateEncodingUsage;
 
-            if (entryName.EndsWith("/"))  _currentEntry.MarkAsDirectory();
+            if (entryName.EndsWith("/", StringComparison.Ordinal))  _currentEntry.MarkAsDirectory();
 
             _currentEntry.EmitTimesInWindowsFormatWhenSaving = ((_timestamp & ZipEntryTimestamp.Windows) != 0);
             _currentEntry.EmitTimesInUnixFormatWhenSaving = ((_timestamp & ZipEntryTimestamp.Unix) != 0);

--- a/src/Zlib.Shared/GZipStream.cs
+++ b/src/Zlib.Shared/GZipStream.cs
@@ -189,7 +189,7 @@ namespace Ionic.Zlib
                 {
                     _FileName = _FileName.Replace("/", "\\");
                 }
-                if (_FileName.EndsWith("\\"))
+                if (_FileName.EndsWith("\\", StringComparison.Ordinal))
                     throw new Exception("Illegal filename");
                 if (_FileName.IndexOf("\\") != -1)
                 {


### PR DESCRIPTION
Fixes #218.

The non-ordinal comparison caused file entries with an emoji name to be treated as directories.

DotNetZip treats an entry as a directory if its name ends with `"/"`. This is checked using `string.EndsWith(string)`. That's an issue because `string.EndsWith(string)` uses the current `CultureInfo` to check for the suffix. For all cultures I've tested (including `CultureInfo.InvariantCulture`), the following was true:

```c#
"Files/\u26BE".EndsWith("/") == true
```

`\u26BE` is the Unicode escape sequence for the character ⚾ (U+26BE BASEBALL), which is somehow ignored by `string.EndsWith(string)`. Other emoji characters are also affected by this, but not all emoji. I've yet to see a pattern here.

Using the overload `string.EndsWith(string, StringComparison)` with `StringComparison.Ordinal` fixes this issue.

I've also fixed other calls to `string.EndsWith(string)` as well as `string.StartsWith(string)` (which exposes the same behavior with strings beginning with some emoji characters), which are not strictly related to #218, but are probably problematic as well.