### PR TITLE
create nuget with multi-target using dotnet cli

### DIFF
--- a/src/DotNetZip.sln
+++ b/src/DotNetZip.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E1C14695-E75F-4317-919A-5341EA1F9C01}"
 	ProjectSection(SolutionItems) = preProject
@@ -57,28 +57,32 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Zlib.Shared", "Zlib.Shared\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zlib.Portable", "Zlib.Portable\Zlib.Portable.csproj", "{27C3F919-13F1-4F71-A169-56EB5982CD6D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zip.Android", "Zip.Android\Zip.Android.csproj", "{D4BC9EF7-EE33-461C-BCF5-AF0B48217061}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zip.Android", "Zip.Android\Zip.Android.csproj", "{D4BC9EF7-EE33-461C-BCF5-AF0B48217061}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Zip.Shared", "Zip.Shared\Zip.Shared.shproj", "{7949FE94-56F9-4CC4-BA24-B9C3B3CDF325}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zip.iOS", "Zip.iOS\Zip.iOS.csproj", "{4AD2A092-2C90-4C76-A8D5-4B56F718626F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zip.iOS", "Zip.iOS\Zip.iOS.csproj", "{4AD2A092-2C90-4C76-A8D5-4B56F718626F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zip NetStandard", "Zip NetStandard\Zip NetStandard.csproj", "{C609AB31-BFBA-47BF-B0C4-CF0FE381C938}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ListContents", "ListContents\ListContents.csproj", "{D269BAF7-02BD-4E29-93E9-81E4CBB0BD59}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ListContents", "ListContents\ListContents.csproj", "{D269BAF7-02BD-4E29-93E9-81E4CBB0BD59}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zip DotNet", "Zip DotNet\Zip DotNet.csproj", "{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		Zlib.Shared\Zlib.Shared.projitems*{27c3f919-13f1-4f71-a169-56eb5982cd6d}*SharedItemsImports = 4
+		Zip.Shared\Zip.Shared.projitems*{34cf4bea-64fd-43e0-9ee6-1f155b453ad3}*SharedItemsImports = 5
+		Zlib.Shared\Zlib.Shared.projitems*{34cf4bea-64fd-43e0-9ee6-1f155b453ad3}*SharedItemsImports = 5
 		Zip.Shared\Zip.Shared.projitems*{49a128d3-c3f2-46b1-8f7a-eecd209ea860}*SharedItemsImports = 4
 		Zlib.Shared\Zlib.Shared.projitems*{49a128d3-c3f2-46b1-8f7a-eecd209ea860}*SharedItemsImports = 4
-		Zip.Shared\Zip.Shared.projitems*{4ad2a092-2c90-4c76-a8d5-4b56f718626f}*SharedItemsImports = 4
 		Zip.Shared\Zip.Shared.projitems*{7949fe94-56f9-4cc4-ba24-b9c3b3cdf325}*SharedItemsImports = 13
 		Zlib.Shared\Zlib.Shared.projitems*{9816ba86-9250-4c00-a912-25f07f8677d1}*SharedItemsImports = 4
+		Zip.Shared\Zip.Shared.projitems*{c609ab31-bfba-47bf-b0c4-cf0fe381c938}*SharedItemsImports = 5
+		Zlib.Shared\Zlib.Shared.projitems*{c609ab31-bfba-47bf-b0c4-cf0fe381c938}*SharedItemsImports = 5
 		Zlib.Shared\Zlib.Shared.projitems*{c6b960da-45d1-4d38-8697-05c0ba439503}*SharedItemsImports = 13
 		Zip.Shared\Zip.Shared.projitems*{d3b0ad67-44d8-4b3d-bed9-ce1fd6de2c5a}*SharedItemsImports = 4
 		Zlib.Shared\Zlib.Shared.projitems*{d3b0ad67-44d8-4b3d-bed9-ce1fd6de2c5a}*SharedItemsImports = 4
-		Zip.Shared\Zip.Shared.projitems*{d4bc9ef7-ee33-461c-bcf5-af0b48217061}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -437,6 +441,22 @@ Global
 		{D269BAF7-02BD-4E29-93E9-81E4CBB0BD59}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{D269BAF7-02BD-4E29-93E9-81E4CBB0BD59}.Release|x86.ActiveCfg = Release|Any CPU
 		{D269BAF7-02BD-4E29-93E9-81E4CBB0BD59}.Release|x86.Build.0 = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|ARM.Build.0 = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Debug|x86.Build.0 = Debug|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|ARM.ActiveCfg = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|ARM.Build.0 = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|x86.ActiveCfg = Release|Any CPU
+		{34CF4BEA-64FD-43E0-9EE6-1F155B453AD3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Zip DotNet/GenerateNuGetPackage.cmd
+++ b/src/Zip DotNet/GenerateNuGetPackage.cmd
@@ -1,0 +1,1 @@
+dotnet pack ".\Zip DotNet.csproj" -c Release -p:PackageVersion=%1 -p:AssemblyVersion=%1 /p:Version=%1 --output .nugets /p:IsCIBuild=%2

--- a/src/Zip DotNet/Zip DotNet.csproj
+++ b/src/Zip DotNet/Zip DotNet.csproj
@@ -1,0 +1,60 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net48;netstandard2.1</TargetFrameworks>
+    <RootNamespace>Ionic.Zip</RootNamespace>
+    <AssemblyName>DotNetZip</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <IsCIBuild>false</IsCIBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants>AESCRYPTO;BZIP</DefineConstants>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\Ionic.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>embedded</DebugType>
+    <ContinuousIntegrationBuild>$(IsCIBuild)</ContinuousIntegrationBuild>
+    <PackageVersion>1.16.0</PackageVersion>
+    <Title>DotNetZip</Title>
+    <Authors>Henrik/Dino Chiesa</Authors>
+    <Description>A fork of the DotNetZip project without signing with a solution that compiles cleanly. This project aims to follow semver to avoid versioning conflicts. DotNetZip is a FAST, FREE class library and toolset for manipulating zip files. Use VB, C# or any .NET language to easily create, extract, or update zip files.</Description>
+    <PackageReleaseNotes>Full version: 1.15.0.065e51.</PackageReleaseNotes>
+    <Copyright>Dino Chiesa</Copyright>
+    <PackageTags>DotNetZip</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\BZip2\BitWriter.cs" Link="BZip2\BitWriter.cs" />
+    <Compile Include="..\BZip2\BZip2Compressor.cs" Link="BZip2\BZip2Compressor.cs" />
+    <Compile Include="..\BZip2\BZip2InputStream.cs" Link="BZip2\BZip2InputStream.cs" />
+    <Compile Include="..\BZip2\BZip2OutputStream.cs" Link="BZip2\BZip2OutputStream.cs" />
+    <Compile Include="..\BZip2\ParallelBZip2OutputStream.cs" Link="BZip2\ParallelBZip2OutputStream.cs" />
+    <Compile Include="..\BZip2\Rand.cs" Link="BZip2\Rand.cs" />
+  </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\SolutionInfo.cs" Link="SolutionInfo.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="System.Security.Permissions" Version="6.0.0" />
+      <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
+    </ItemGroup>
+
+    <Import Project="..\Zlib.Shared\Zlib.Shared.projitems" Label="Shared" />
+
+    <Import Project="..\Zip.Shared\Zip.Shared.projitems" Label="Shared" />
+
+</Project>

--- a/src/Zip DotNet/readme.md
+++ b/src/Zip DotNet/readme.md
@@ -1,0 +1,20 @@
+# Zip DotNet description
+
+This project contains multiple monikers (**net6.0**, **net48** and **netstandard2.1**) and links files and references projects the same way as `Zip NetStandard` project.  
+It was made to simplify nuget package generation and to remove strict version dependency on *System.Security.Permissions 5.0* and *System.Text.Encoding.CodePages 5.0*.  
+
+Metadata from nuspec is copied to property group in .csproj file.
+
+As addition, SourceLink is enabled to allow to debug the library.
+
+This project uses dotnet 6 sdk, so it should be installed prior to the build.
+
+In order to generate the nuget package, just run `GenerateNuGetPackage.cmd` with parameters from within this project folder
+
+```
+    GenerateNuGetPackage.cmd 1.16.0 'true'
+```
+First parameter is version of the package and the assembly.  
+Second is a flag indicating if this package was created from CI.
+
+Newly created nuget packages will appear in `.nugets` folder.


### PR DESCRIPTION
This is a try to fix strict dependency on *System.Security.Permissions 5.0* and *System.Text.Encoding.CodePages 5.0* (https://github.com/haf/DotNetZip.Semverd/issues/245), yet to modernize a bit this solution, using dotnet 6.0 cli for nuget package creation.

It's been tested (at least the part that we use in our project) on a .net 6 project.

If this approach happens to be acceptable, then probably `Zip NetStandard.csproj` and `Zip DLL.csproj` can be merged with this new `Zip DotNet.csproj`