### PR TITLE
Switch to lower dependencies

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
-:minor: 15
+:minor: 16
 :patch: 0
 :special: ''
 :metadata: ''

--- a/Rakefile
+++ b/Rakefile
@@ -81,6 +81,7 @@ class Albacore::NugetModel::Package
   def to_template
     template = self.orig_to_template
     if @metadata.id == 'DotNetZip'
+	  template = template.map { |s| s.sub '~>', '>=' }
       before = template.take_while { |l| l != 'dependencies' }
       after = template.drop_while { |l| l != 'dependencies' }.drop(1)
       template = [

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,7 +1,11 @@
+source https://api.nuget.org/v3/index.json
+
 framework: auto-detect
 storage: none
+content: none
 
-source https://www.nuget.org/api/v2
-nuget System.Security.Permissions
-nuget System.Text.Encoding.CodePages
-nuget System.Text.Encoding.Extensions
+nuget System.Runtime.CompilerServices.Unsafe !~> 4.7
+nuget System.Security.AccessControl !~> 4.7
+nuget System.Security.Permissions !~> 4.7
+nuget System.Security.Principal.Windows !~> 4.7
+nuget System.Text.Encoding.CodePages !~> 4.7

--- a/paket.lock
+++ b/paket.lock
@@ -1,26 +1,13 @@
 STORAGE: NONE
+CONTENT: NONE
 RESTRICTION: == netstandard2.0
 NUGET
-  remote: https://www.nuget.org/api/v2
-    Microsoft.NETCore.Platforms (5.0)
-    Microsoft.NETCore.Targets (5.0)
-    System.Runtime (4.3.1)
-      Microsoft.NETCore.Platforms (>= 1.1.1)
-      Microsoft.NETCore.Targets (>= 1.1.3)
-    System.Runtime.CompilerServices.Unsafe (5.0)
-    System.Security.AccessControl (5.0)
-      System.Security.Principal.Windows (>= 5.0)
-    System.Security.Permissions (5.0)
-      System.Security.AccessControl (>= 5.0)
-    System.Security.Principal.Windows (5.0)
-    System.Text.Encoding (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1)
-      Microsoft.NETCore.Targets (>= 1.1)
-      System.Runtime (>= 4.3)
-    System.Text.Encoding.CodePages (5.0)
-      System.Runtime.CompilerServices.Unsafe (>= 5.0)
-    System.Text.Encoding.Extensions (4.3)
-      Microsoft.NETCore.Platforms (>= 1.1)
-      Microsoft.NETCore.Targets (>= 1.1)
-      System.Runtime (>= 4.3)
-      System.Text.Encoding (>= 4.3)
+  remote: https://api.nuget.org/v3/index.json
+    System.Runtime.CompilerServices.Unsafe (4.7.1)
+    System.Security.AccessControl (4.7)
+      System.Security.Principal.Windows (>= 4.7)
+    System.Security.Permissions (4.7)
+      System.Security.AccessControl (>= 4.7)
+    System.Security.Principal.Windows (4.7)
+    System.Text.Encoding.CodePages (4.7.1)
+      System.Runtime.CompilerServices.Unsafe (>= 4.7.1)

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -1,6 +1,7 @@
+
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-[assembly: AssemblyVersion("1.15.0")]
-[assembly: AssemblyFileVersion("1.15.0")]
-[assembly: AssemblyInformationalVersion("1.15.0.000000")]
+[assembly: AssemblyVersion("1.16.0")]
+[assembly: AssemblyFileVersion("1.16.0")]
+[assembly: AssemblyInformationalVersion("1.16.0.000000")]


### PR DESCRIPTION
A small hack to replace templates to lower dependencies. Now package dependencies section looks like this:

![image](https://user-images.githubusercontent.com/171892/141947253-4c1387cc-1198-410e-be60-6d358531c2fd.png)

Compared to current NuGet feed:

![image](https://user-images.githubusercontent.com/171892/141947470-3028161c-274b-49b2-9e5b-ad2ae0d980e0.png)
