### PR TITLE
increase margin of safety for seek on end of central directory

### DIFF
--- a/src/Zip.Shared/ZipFile.Read.cs
+++ b/src/Zip.Shared/ZipFile.Read.cs
@@ -581,7 +581,7 @@ namespace Ionic.Zip
                 // safety and start "in front" of that, when looking for the
                 // EndOfCentralDirectorySignature
                 long posn = s.Length - 64;
-                long maxSeekback = Math.Max(s.Length - 0x4000, 10);
+                long maxSeekback = Math.Max(s.Length - 0x8000, 10);
                 do
                 {
                     if (posn < 0) posn = 0;  // BOF


### PR DESCRIPTION
I have several self-extracting zip files (in a `.exe` format) generated from Winzip that cannot be read within DotNetZip. Typically this is not problematic but through a combination of events the file is unable to be read. 

These files have more metadata after the end of the central directory than most. The safety net for seeking to find the `EndOfCentralDirectorySignature` is not large enough in this case to accurately find the signature, though it is present in the file. 

Because the `EndOfCentralDirectorySignature` is not found we eventually fall back to the `ReadIntoInstance_Orig()` method. This will check the headers and recognize (correctly) that the file does not begin with `ZipDirEntrySignature` because it's a `.exe` type. Here we receive an exception `Bad signature (0x00905A4D) at position  0x00000000`. If the `EndOfCentralDirectorySignature` is found then this bad signature exception is never thrown.

This pull request doubles the safety net for finding the end of the central directory signature. In effect, this avoids all downstream effects for this atypical file format. Thanks for your consideration. 
