### PR TITLE
Performance improvement for zipping with AES encryption

### DIFF
--- a/src/Zip Tests/WinZipAesTests.cs
+++ b/src/Zip Tests/WinZipAesTests.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Ionic.Zip;
 using Ionic.Zip.Tests.Utilities;
+using System.Linq;
 
 namespace Ionic.Zip.Tests.WinZipAes
 {
@@ -606,6 +607,81 @@ namespace Ionic.Zip.Tests.WinZipAes
                         string expectedCheckString = checksums[e.FileName];
                         string actualCheckString = TestUtilities.CheckSumToString(TestUtilities.ComputeChecksum(PathToExtractedFile));
                         Assert.AreEqual<String>(expectedCheckString, actualCheckString, "Unexpected checksum on extracted filesystem file ({0}).", PathToExtractedFile);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void WZA_CreateZip_MultipleEntriesDifferentPasswords()
+        {
+            if (!WinZipIsPresent)
+                throw new Exception("no winzip! [WZA_CreateZip_MultipleEntriesDifferentPasswords]");
+
+            string zipFileToCreate = "WZA_CreateZip_MultipleEntriesDifferentPasswords.zip";
+
+            string[] passwords = 
+            { 
+                TestUtilities.GenerateRandomPassword(), 
+                TestUtilities.GenerateRandomPassword(), 
+                TestUtilities.GenerateRandomPassword() 
+            };
+
+            TestContext.WriteLine("=======================================");
+            TestContext.WriteLine("Creating file {0}", zipFileToCreate);
+            TestContext.WriteLine("  Passwords:   {0}", string.Join(", ", passwords));
+            int entries = _rnd.Next(21) + 5;
+
+            string filename = null;
+            var checksums = new Dictionary<string, string>();
+            using (ZipFile zip1 = new ZipFile())
+            {
+                zip1.Encryption = EncryptionAlgorithm.WinZipAes256;
+                zip1.CompressionLevel = Ionic.Zlib.CompressionLevel.None;
+
+                for (int i = 0; i < entries; i++)
+                {
+                    zip1.Password = passwords[i % 3];
+                    if (_rnd.Next(2) == 1)
+                    {
+                        filename = Path.Combine(TopLevelDir, String.Format("Data{0}.bin", i));
+                        int filesize = _rnd.Next(144000) + 5000;
+                        TestUtilities.CreateAndFillFileBinary(filename, filesize);
+                    }
+                    else
+                    {
+                        filename = Path.Combine(TopLevelDir, String.Format("Data{0}.txt", i));
+                        int filesize = _rnd.Next(144000) + 5000;
+                        TestUtilities.CreateAndFillFileText(filename, filesize);
+                    }
+                    zip1.AddFile(filename, "");
+
+                    var chk = TestUtilities.ComputeChecksum(filename);
+                    checksums.Add(Path.GetFileName(filename), TestUtilities.CheckSumToString(chk));
+                }
+
+                zip1.Comment = String.Format("This archive uses Encryption({0}) passwords({1}) no compression.", zip1.Encryption, string.Join(", ", passwords));
+                zip1.Save(zipFileToCreate);
+            }
+
+            // validate all the checksums
+            using (ZipFile zip2 = ZipFile.Read(zipFileToCreate))
+            {
+                int i = 0;
+                foreach (ZipEntry e in zip2)
+                {
+                    if (!e.IsDirectory)
+                    {
+                        Assert.AreEqual<short>(0, (short)e.CompressionMethod);
+                        e.ExtractWithPassword("unpack", passwords[i % 3]);
+                        string PathToExtractedFile = Path.Combine("unpack", e.FileName);
+                        Assert.IsTrue(checksums.ContainsKey(e.FileName));
+
+                        // verify the checksum of the file is correct
+                        string expectedCheckString = checksums[e.FileName];
+                        string actualCheckString = TestUtilities.CheckSumToString(TestUtilities.ComputeChecksum(PathToExtractedFile));
+                        Assert.AreEqual<String>(expectedCheckString, actualCheckString, "Unexpected checksum on extracted filesystem file ({0}).", PathToExtractedFile);
+                        i++;
                     }
                 }
             }

--- a/src/Zip Tests/WinZipAesTests.cs
+++ b/src/Zip Tests/WinZipAesTests.cs
@@ -688,12 +688,12 @@ namespace Ionic.Zip.Tests.WinZipAes
         }
 
         [TestMethod]
-        public void WZA_CreateZip_MultipleEntriesDifferentEncrytion()
+        public void WZA_CreateZip_MultipleEntriesDifferentEncryption()
         {
             if (!WinZipIsPresent)
-                throw new Exception("no winzip! [WZA_CreateZip_MultipleEntriesDifferentEncrytion]");
+                throw new Exception("no winzip! [WZA_CreateZip_MultipleEntriesDifferentEncryption]");
 
-            string zipFileToCreate = "WZA_CreateZip_MultipleEntriesDifferentEncrytion.zip";
+            string zipFileToCreate = "WZA_CreateZip_MultipleEntriesDifferentEncryption.zip";
 
             string password = TestUtilities.GenerateRandomPassword();
 

--- a/src/Zip.Shared/ZipEntry.Write.cs
+++ b/src/Zip.Shared/ZipEntry.Write.cs
@@ -2085,7 +2085,19 @@ namespace Ionic.Zip
                 _ioOperationCanceled = _container.ZipFile.OnZipErrorSaving(this, e);
         }
 
+#if AESCRYPTO
+        internal static WinZipAesCrypto CalculateAesCryptoKey(EncryptionAlgorithm encryption, string pwd)
+        {
+            int keystrength = GetKeyStrengthInBits(encryption);
+            return WinZipAesCrypto.Generate(pwd, keystrength);
+        }
 
+        internal void Write(Stream outstream, WinZipAesCrypto aesCrypto_forWrite)
+        {
+            _aesCrypto_forWrite = aesCrypto_forWrite;
+            Write(outstream);
+        }
+#endif
 
         internal void Write(Stream s)
         {
@@ -2396,7 +2408,10 @@ namespace Ionic.Zip
                 // verification" value for the entry.
 
                 int keystrength = GetKeyStrengthInBits(Encryption);
-                _aesCrypto_forWrite = WinZipAesCrypto.Generate(pwd, keystrength);
+                if (_aesCrypto_forWrite == null)
+                {
+                    _aesCrypto_forWrite = WinZipAesCrypto.Generate(pwd, keystrength);
+                }
                 outstream.Write(_aesCrypto_forWrite.Salt, 0, _aesCrypto_forWrite._Salt.Length);
                 outstream.Write(_aesCrypto_forWrite.GeneratedPV, 0, _aesCrypto_forWrite.GeneratedPV.Length);
                 _LengthOfHeader += _aesCrypto_forWrite._Salt.Length + _aesCrypto_forWrite.GeneratedPV.Length;

--- a/src/Zip.Shared/ZipEntry.Write.cs
+++ b/src/Zip.Shared/ZipEntry.Write.cs
@@ -27,6 +27,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using RE = System.Text.RegularExpressions;
 
@@ -2086,10 +2087,18 @@ namespace Ionic.Zip
         }
 
 #if AESCRYPTO
-        internal static WinZipAesCrypto CalculateAesCryptoKey(EncryptionAlgorithm encryption, string pwd)
-        {
-            int keystrength = GetKeyStrengthInBits(encryption);
-            return WinZipAesCrypto.Generate(pwd, keystrength);
+        internal WinZipAesCrypto CalculateAesCryptoKey(Dictionary<string,WinZipAesCrypto> preCalculatedKeys) {
+            WinZipAesCrypto aesCryptoKey;
+
+            bool alreadyCalculatedKey = preCalculatedKeys.TryGetValue(this.Password, out aesCryptoKey);
+
+            if(!alreadyCalculatedKey) {
+                int keystrength = GetKeyStrengthInBits(this.Encryption);
+                aesCryptoKey = WinZipAesCrypto.Generate(this.Password, keystrength);
+                preCalculatedKeys[this.Password] = aesCryptoKey;
+            }
+
+            return aesCryptoKey;
         }
 
         internal void Write(Stream outstream, WinZipAesCrypto aesCrypto_forWrite)

--- a/src/Zip.Shared/ZipEntry.Write.cs
+++ b/src/Zip.Shared/ZipEntry.Write.cs
@@ -2087,17 +2087,18 @@ namespace Ionic.Zip
         }
 
 #if AESCRYPTO
-        internal WinZipAesCrypto CalculateAesCryptoKey(Dictionary<string,WinZipAesCrypto> preCalculatedKeys) {
+        internal WinZipAesCrypto CalculateAesCryptoKey(Dictionary<Tuple<EncryptionAlgorithm, string>, WinZipAesCrypto> preCalculatedKeys) {
             if (this.Password == null) { return null; }
 
             WinZipAesCrypto aesCryptoKey;
 
-            bool alreadyCalculatedKey = preCalculatedKeys.TryGetValue(this.Password, out aesCryptoKey);
+            Tuple<EncryptionAlgorithm, string> strengthAndPasswordDictKey = new Tuple<EncryptionAlgorithm, string>(this.Encryption, this.Password);
+            bool alreadyCalculatedKey = preCalculatedKeys.TryGetValue(strengthAndPasswordDictKey, out aesCryptoKey);
 
             if(!alreadyCalculatedKey) {
                 int keystrength = GetKeyStrengthInBits(this.Encryption);
                 aesCryptoKey = WinZipAesCrypto.Generate(this.Password, keystrength);
-                preCalculatedKeys[this.Password] = aesCryptoKey;
+                preCalculatedKeys[strengthAndPasswordDictKey] = aesCryptoKey;
             }
 
             return aesCryptoKey;

--- a/src/Zip.Shared/ZipEntry.Write.cs
+++ b/src/Zip.Shared/ZipEntry.Write.cs
@@ -2419,9 +2419,9 @@ namespace Ionic.Zip
                 // preceded by a variable-sized Salt and a 2-byte "password
                 // verification" value for the entry.
 
-                int keystrength = GetKeyStrengthInBits(Encryption);
                 if (_aesCrypto_forWrite == null)
                 {
+                    int keystrength = GetKeyStrengthInBits(Encryption);
                     _aesCrypto_forWrite = WinZipAesCrypto.Generate(pwd, keystrength);
                 }
                 outstream.Write(_aesCrypto_forWrite.Salt, 0, _aesCrypto_forWrite._Salt.Length);
@@ -2429,7 +2429,7 @@ namespace Ionic.Zip
                 _LengthOfHeader += _aesCrypto_forWrite._Salt.Length + _aesCrypto_forWrite.GeneratedPV.Length;
 
                 TraceWriteLine("WriteSecurityMetadata: AES e({0}) keybits({1}) _LOH({2})",
-                               FileName, keystrength, _LengthOfHeader);
+                               FileName, _aesCrypto_forWrite._KeyStrengthInBits, _LengthOfHeader);
 
             }
 #endif

--- a/src/Zip.Shared/ZipEntry.Write.cs
+++ b/src/Zip.Shared/ZipEntry.Write.cs
@@ -2088,6 +2088,8 @@ namespace Ionic.Zip
 
 #if AESCRYPTO
         internal WinZipAesCrypto CalculateAesCryptoKey(Dictionary<string,WinZipAesCrypto> preCalculatedKeys) {
+            if (this.Password == null) { return null; }
+
             WinZipAesCrypto aesCryptoKey;
 
             bool alreadyCalculatedKey = preCalculatedKeys.TryGetValue(this.Password, out aesCryptoKey);

--- a/src/Zip.Shared/ZipFile.Save.cs
+++ b/src/Zip.Shared/ZipFile.Save.cs
@@ -161,7 +161,7 @@ namespace Ionic.Zip
                 // write an entry in the zip for each file
                 int n = 0;
 #if AESCRYPTO
-                Dictionary<string, WinZipAesCrypto> sharedEncryptionKeys = new Dictionary<string, WinZipAesCrypto>();
+                Dictionary<Tuple<EncryptionAlgorithm,string>, WinZipAesCrypto> sharedEncryptionKeys = new Dictionary<Tuple<EncryptionAlgorithm, string>, WinZipAesCrypto>();
 #endif
 
                 // workitem 9831


### PR DESCRIPTION
I left an issue about this (#271), but these changes will fix the issue.

These were the results I got from some performance testing:
![image](https://user-images.githubusercontent.com/43353686/206538516-421a9053-4a4e-4e8c-8c4b-921e989e3ce3.png)

I tested with varying the encryption types (PKzipWeak vs WinZipAes256) with different compression types (Level9, Level4, and Level0) when compressing an 86.9MB folder with 2282 files. When using WinZipAes256 encryption (bottom 3 rows) we can see that after the performance changes made by this commit (last column) we saw ~85-73% (depending on the compression level) reduction in runtime compared to before the performance changes made by this commit (second last column).

If you need me to clean up the code at all before merging these changes, please let me know. Thanks!
